### PR TITLE
Add resources for tenants, redirect URIs and allowed origins

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -53,6 +53,9 @@ func New(version string) func() *schema.Provider {
 				"frontegg_role":                resourceFronteggRole(),
 				"frontegg_webhook":             resourceFronteggWebhook(),
 				"frontegg_workspace":           resourceFronteggWorkspace(),
+				"frontegg_tenant":              resourceFronteggTenant(),
+				"frontegg_redirect_uri":        resourceFronteggRedirectUri(),
+				"frontegg_allowed_origin":      resourceFronteggAllowedOrigin(),
 			},
 			ConfigureContextFunc: func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 				apiClient := restclient.MakeRestClient(d.Get("api_base_url").(string))
@@ -66,9 +69,9 @@ func New(version string) func() *schema.Provider {
 						SecretKey: d.Get("secret_key").(string),
 					}
 					var out struct {
-						AccessToken string `json:"accessToken"`
+						AccessToken string `json:"token"`
 					}
-					err := portalClient.Post(ctx, "/frontegg/identity/resources/auth/v1/api-token", in, &out)
+					err := apiClient.Post(ctx, "/auth/vendor", in, &out)
 					if err != nil {
 						return nil, diag.Errorf("unable to authenticate with frontegg: %s", err)
 					}

--- a/provider/resource_frontegg_allowed_origin.go
+++ b/provider/resource_frontegg_allowed_origin.go
@@ -1,0 +1,134 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const fronteggAllowedOriginPath = "/vendors"
+
+type fronteggAllowedOrigins struct {
+	AllowedOrigins []string `json:"allowedOrigins,omitempty"`
+}
+
+func resourceFronteggAllowedOrigin() *schema.Resource {
+	return &schema.Resource{
+		Description: `Configures a Frontegg allowed origin.`,
+
+		CreateContext: resourceFronteggAllowedOriginCreate,
+		ReadContext:   resourceFronteggAllowedOriginRead,
+		DeleteContext: resourceFronteggAllowedOriginDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"allowed_origin": {
+				Description: "The allowed origin URI.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceFronteggAllowedOriginCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	allowedOrigins, err := getAllowedOrigins(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	newOrigin := d.Get("allowed_origin").(string)
+	if containsAllowedOrigin(allowedOrigins, newOrigin) {
+		return diag.FromErr(fmt.Errorf("Origin '%s' already exists", newOrigin))
+	}
+
+	allowedOrigins.AllowedOrigins = append(allowedOrigins.AllowedOrigins, newOrigin)
+
+	if err := updateAllowedOrigins(ctx, meta, allowedOrigins); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(newOrigin)
+	d.Set("allowed_origin", newOrigin)
+
+	return nil
+}
+
+func resourceFronteggAllowedOriginRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	allowedOrigins, err := getAllowedOrigins(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	origin := d.Get("allowed_origin").(string)
+	if !containsAllowedOrigin(allowedOrigins, origin) {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(origin)
+	d.Set("allowed_origin", origin)
+
+	return nil
+}
+
+func resourceFronteggAllowedOriginDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	allowedOrigins, err := getAllowedOrigins(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	originToDelete := d.Get("allowed_origin").(string)
+	if !containsAllowedOrigin(allowedOrigins, originToDelete) {
+		return diag.FromErr(fmt.Errorf("Origin '%s' does not exist", originToDelete))
+	}
+
+	newOrigins := make([]string, 0, len(allowedOrigins.AllowedOrigins)-1)
+	for _, origin := range allowedOrigins.AllowedOrigins {
+		if origin != originToDelete {
+			newOrigins = append(newOrigins, origin)
+		}
+	}
+	allowedOrigins.AllowedOrigins = newOrigins
+
+	if err := updateAllowedOrigins(ctx, meta, allowedOrigins); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func getAllowedOrigins(ctx context.Context, meta interface{}) (*fronteggAllowedOrigins, error) {
+	clientHolder := meta.(*restclient.ClientHolder)
+	var out fronteggAllowedOrigins
+	if err := clientHolder.ApiClient.Get(ctx, fronteggAllowedOriginPath, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func updateAllowedOrigins(ctx context.Context, meta interface{}, origins *fronteggAllowedOrigins) error {
+	clientHolder := meta.(*restclient.ClientHolder)
+	if err := clientHolder.ApiClient.Put(ctx, fronteggAllowedOriginPath, origins, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func containsAllowedOrigin(origins *fronteggAllowedOrigins, newOrigin string) bool {
+	for _, origin := range origins.AllowedOrigins {
+		if origin == newOrigin {
+			return true
+		}
+	}
+
+	return false
+}

--- a/provider/resource_frontegg_redirect_uri.go
+++ b/provider/resource_frontegg_redirect_uri.go
@@ -1,0 +1,113 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const fronteggRedirectUriPath = "/oauth/resources/configurations/v1/redirect-uri"
+
+type fronteggRedirectUri struct {
+	RedirectUri string `json:"redirectUri,omitempty"`
+	Key         string `json:"id,omitempty"`
+}
+
+func resourceFronteggRedirectUri() *schema.Resource {
+	return &schema.Resource{
+		Description: `Configures a Frontegg Redirect URI.`,
+
+		CreateContext: resourceFronteggRedirectUriCreate,
+		ReadContext:   resourceFronteggRedirectUriRead,
+		DeleteContext: resourceFronteggRedirectUriDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"redirect_uri": {
+				Description: "The redirect URI.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"key": {
+				Description: "The redirect URI key.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceFronteggRedirectUriSerialize(d *schema.ResourceData) fronteggRedirectUri {
+	return fronteggRedirectUri{
+		Key:         d.Get("key").(string),
+		RedirectUri: d.Get("redirect_uri").(string),
+	}
+}
+
+func resourceFronteggRedirectUriDeserialize(d *schema.ResourceData, f fronteggRedirectUri) error {
+	d.SetId(f.Key)
+	if err := d.Set("key", f.Key); err != nil {
+		return err
+	}
+	if err := d.Set("redirect_uri", f.RedirectUri); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceFronteggRedirectUriCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientHolder := meta.(*restclient.ClientHolder)
+	in := resourceFronteggRedirectUriSerialize(d)
+	if err := clientHolder.ApiClient.Post(ctx, fronteggRedirectUriPath, in, nil); err != nil {
+		return diag.FromErr(err)
+	}
+	var out struct {
+		RedirectURIs []fronteggRedirectUri `json:"redirectUris"`
+	}
+	if err := clientHolder.ApiClient.Get(ctx, fmt.Sprintf("%s", fronteggRedirectUriPath), &out); err != nil {
+		return diag.FromErr(err)
+	}
+	for _, c := range out.RedirectURIs {
+		if c.RedirectUri == in.RedirectUri {
+			if err := resourceFronteggRedirectUriDeserialize(d, c); err != nil {
+				return diag.FromErr(err)
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func resourceFronteggRedirectUriRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientHolder := meta.(*restclient.ClientHolder)
+	var out struct {
+		RedirectURIs []fronteggRedirectUri `json:"redirectUris"`
+	}
+	if err := clientHolder.ApiClient.Get(ctx, fmt.Sprintf("%s", fronteggRedirectUriPath), &out); err != nil {
+		return diag.FromErr(err)
+	}
+	for _, c := range out.RedirectURIs {
+		if c.Key == d.Id() {
+			if err := resourceFronteggRedirectUriDeserialize(d, c); err != nil {
+				return diag.FromErr(err)
+			}
+			return nil
+		}
+	}
+	d.SetId("")
+	return nil
+}
+
+func resourceFronteggRedirectUriDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientHolder := meta.(*restclient.ClientHolder)
+	if err := clientHolder.ApiClient.Delete(ctx, fmt.Sprintf("%s/%s", fronteggRedirectUriPath, d.Id()), nil); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/provider/resource_frontegg_tenant.go
+++ b/provider/resource_frontegg_tenant.go
@@ -1,0 +1,125 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const fronteggTenantPath = "/tenants/resources/tenants/v1"
+
+type fronteggTenant struct {
+	Key            string `json:"tenantId,omitempty"`
+	Name           string `json:"name,omitempty"`
+	ApplicationUri string `json:"applicationUrl,omitempty"`
+}
+
+func resourceFronteggTenant() *schema.Resource {
+	return &schema.Resource{
+		Description: `Configures a Frontegg tenant.`,
+
+		CreateContext: resourceFronteggTenantCreate,
+		ReadContext:   resourceFronteggTenantRead,
+		UpdateContext: resourceFronteggTenantUpdate,
+		DeleteContext: resourceFronteggTenantDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "A human-readable name for the tenant.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"key": {
+				Description: "A human-readable identifier for the tenant.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"application_uri": {
+				Description: "The application URI for this tenant.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func resourceFronteggTenantSerialize(d *schema.ResourceData) fronteggTenant {
+	return fronteggTenant{
+		Name:           d.Get("name").(string),
+		Key:            d.Get("key").(string),
+		ApplicationUri: d.Get("application_uri").(string),
+	}
+}
+
+func resourceFronteggTenantDeserialize(d *schema.ResourceData, f fronteggTenant) error {
+	d.SetId(f.Key)
+	if err := d.Set("name", f.Name); err != nil {
+		return err
+	}
+	if err := d.Set("key", f.Key); err != nil {
+		return err
+	}
+	if err := d.Set("application_uri", f.ApplicationUri); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceFronteggTenantCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientHolder := meta.(*restclient.ClientHolder)
+	in := resourceFronteggTenantSerialize(d)
+	var out fronteggTenant
+	if err := clientHolder.ApiClient.Post(ctx, fronteggTenantPath, in, &out); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := resourceFronteggTenantDeserialize(d, out); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceFronteggTenantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientHolder := meta.(*restclient.ClientHolder)
+	var out []fronteggTenant
+	if err := clientHolder.ApiClient.Get(ctx, fmt.Sprintf("%s/%s", fronteggTenantPath, d.Id()), &out); err != nil {
+		return diag.FromErr(err)
+	}
+	for _, c := range out {
+		if c.Key == d.Id() {
+			if err := resourceFronteggTenantDeserialize(d, c); err != nil {
+				return diag.FromErr(err)
+			}
+			return nil
+		}
+	}
+	d.SetId("")
+	return nil
+}
+
+func resourceFronteggTenantUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientHolder := meta.(*restclient.ClientHolder)
+	var out fronteggTenant
+	in := resourceFronteggTenantSerialize(d)
+	if err := clientHolder.ApiClient.Put(ctx, fmt.Sprintf("%s/%s", fronteggTenantPath, d.Id()), in, &out); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := resourceFronteggTenantDeserialize(d, out); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceFronteggTenantDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientHolder := meta.(*restclient.ClientHolder)
+	if err := clientHolder.ApiClient.Delete(ctx, fmt.Sprintf("%s/%s", fronteggTenantPath, d.Id()), nil); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds three new resources:

* Tenant
* Redirect URI
* Allowed Origin

With these, it is easier to programmatically define these resources using IaC.

Additionally, it changes the authentication mechanism to leverage the client_id/secret from the Workspace itself, rather than requiring a "personal access token", using the `/auth/vendor` endpoint. I don't know if this is the right thing, but it does empirically work.