### PR TITLE
Add test validating provider & resource schemas; fix failing validation

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestValidateProviderSchema(t *testing.T) {
+	scm := schema.InternalMap(New("0.0.0")().Schema)
+	if err := scm.InternalValidate(nil); err != nil {
+		t.Errorf("Schema failed to validate: %v", err)
+	}
+}
+
+func TestValidateResourceSchemas(t *testing.T) {
+	prov := New("0.0.0")()
+	for name, res := range prov.ResourcesMap {
+		test := res
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			scm := schema.InternalMap(test.Schema)
+			if err := scm.InternalValidate(nil); err != nil {
+				t.Errorf("Schema failed to validate: %v", err)
+			}
+		})
+	}
+}

--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -578,7 +578,7 @@ per Frontegg provider.`,
 						"redirect_url": {
 							Description: "The redirect URL to redirect after the SAML ",
 							Type:        schema.TypeString,
-							Required:    false,
+							Optional:    true,
 						},
 					},
 				},


### PR DESCRIPTION
I was trying to use the latest master branch head and saw a validation failure from pulumi's tf adapter:

```
        * InternalValidate: Internal validation of the provider failed! This is always a bug
    with the provider itself, and not a user issue. Please report
    this bug:

    1 error occurred:
        * resource frontegg_workspace: redirect_url: One of optional, required, or computed must be set
```

So, I dug some & found out that terraform has a function that validates schemas for us! Added that as a test (multiple, in fact) and now we're validating the schema against terraform's idea of a well-formed schema. This exposed the bug, and I'm fixing it in this PR to make CI be nice and green.