### PR TITLE
fix crash when web page style has not been modified

### DIFF
--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -1625,10 +1625,11 @@ func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		var configuration fronteggAdminPortalConfiguration
+		var adminPortal []fronteggAdminPortal
 		// adminBox is only defined when the default style of the web page has been modified, if not it's 0 rows and
 		// this is not an error.
 		if len(out.Rows) > 0 {
-			adminPortal := out.Rows[0]
+			adminPortal = out.Rows[0]
 			configuration = adminPortal.Configuration
 		}
 

--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -1625,7 +1625,7 @@ func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		var configuration fronteggAdminPortalConfiguration
-		var adminPortal []fronteggAdminPortal
+		var adminPortal fronteggAdminPortal
 		// adminBox is only defined when the default style of the web page has been modified, if not it's 0 rows and
 		// this is not an error.
 		if len(out.Rows) > 0 {

--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -1624,9 +1624,14 @@ func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData
 			return diag.FromErr(err)
 		}
 
-		adminPortal := out.Rows[0]
+		var configuration fronteggAdminPortalConfiguration
+		// adminBox is only defined when the default style of the web page has been modified, if not it's 0 rows and
+		// this is not an error.
+		if len(out.Rows) > 0 {
+			adminPortal := out.Rows[0]
+			configuration = adminPortal.Configuration
+		}
 
-		configuration := adminPortal.Configuration
 		configuration.Navigation.Account = serializeVisibility("admin_portal.0.enable_account_settings")
 		configuration.Navigation.APITokens = serializeVisibility("admin_portal.0.enable_api_tokens")
 		configuration.Navigation.Audits = serializeVisibility("admin_portal.0.enable_audit_logs")


### PR DESCRIPTION
This should fix this crash where the webpage style has not been updated which means `adminBox` returns 0 rows and causes an index out of range exception.

```panic: runtime error: index out of range [0] with length 0
    goroutine 117 [running]:
    github.com/frontegg/terraform-provider-frontegg/provider.resourceFronteggWorkspaceUpdate({0x1030c05c8?, 0x14000114240}, 0x1400059b280, {0x102ec1e20?, 0x1400044e8f0})
    	/home/runner/go/pkg/mod/github.com/frontegg/terraform-provider-frontegg@v0.2.35/provider/resource_frontegg_workspace.go:1408 +0x2cec
    github.com/frontegg/terraform-provider-frontegg/provider.resourceFronteggWorkspaceCreate({0x1030c05c8?, 0x14000114240?}, 0x0?, {0x102ec1e20?, 0x1400044e8f0?})
    	/home/runner/go/pkg/mod/github.com/frontegg/terraform-provider-frontegg@v0.2.35/provider/resource_frontegg_workspace.go:823 +0x30
    github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x14000193ea0, {0x1030c0590, 0x14000042258}, 0xd?, {0x102ec1e20, 0x1400044e8f0})
    	/home/runner/go/pkg/mod/github.com/pulumi/terraform-plugin-sdk/v2@v2.0.0-20220725190814-23001ad6ec03/helper/schema/resource.go:712 +0xec
    github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x14000193ea0, {0x1030c0590, 0x14000042258}, 0x0, 0x1400059b180, {0x102ec1e20, 0x1400044e8f0})
    	/home/runner/go/pkg/mod/github.com/pulumi/terraform-plugin-sdk/v2@v2.0.0-20220725190814-23001ad6ec03/helper/schema/resource.go:842 +0x874
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2.v2Provider.Apply({0x102c6d874?}, {0x102c7a6c9, 0x12}, {0x0?, 0x0}, {0x1030c50b8?, 0x1400059b180})
    	/home/runner/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.26.1/pkg/tfshim/sdk-v2/provider.go:122 +0x15c
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge.(*Provider).Create(0x1400043f440, {0x1030c0600?, 0x140009032f0?}, 0x14000908280)
    	/home/runner/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.26.1/pkg/tfbridge/provider.go:866 +0x494
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Create_Handler.func1({0x1030c0600, 0x140009032f0}, {0x103023fa0?, 0x14000908280})
    	/home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.36.0/proto/go/provider.pb.go:3724 +0x78
    github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc.OpenTracingServerInterceptor.func1({0x1030c0600, 0x14000902b40}, {0x103023fa0, 0x14000908280}, 0x1400087d0e0, 0x1400090a180)
    	/home/runner/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go:57 +0x310
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Create_Handler({0x1030877a0?, 0x1400043f440}, {0x1030c0600, 0x14000902b40}, 0x1400023ce70, 0x1400011efe0)
    	/home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.36.0/proto/go/provider.pb.go:3726 +0x13c
    google.golang.org/grpc.(*Server).processUnaryRPC(0x14000202000, {0x1030c5170, 0x14000602680}, 0x14000900fc0, 0x140004fc5d0, 0x1037bc160, 0x0)
    	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:1295 +0x9d8
    google.golang.org/grpc.(*Server).handleStream(0x14000202000, {0x1030c5170, 0x14000602680}, 0x14000900fc0, 0x0)
    	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:1636 +0x840
    google.golang.org/grpc.(*Server).serveStreams.func1.2()
    	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:932 +0x88
    created by google.golang.org/grpc.(*Server).serveStreams.func1
    	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.48.0/server.go:930 +0x298
```