### PR TITLE
fix misreferenced admin portal config

### DIFF
--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -1700,13 +1700,19 @@ func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData
 			return diag.FromErr(err)
 		}
 
-		var configuration fronteggAdminPortalConfiguration
+		var configuration *fronteggAdminPortalConfiguration
 		var adminPortal fronteggAdminPortal
 		// adminBox is only defined when the default style of the web page has been modified, if not it's 0 rows and
 		// this is not an error.
-		if len(out.Rows) > 0 {
+		switch len(out.Rows) {
+		case 0:
+			log.Printf("[DEBUG] no admin portal found, creating one with default config.")
+			configuration = &adminPortal.Configuration
+		case 1:
 			adminPortal = out.Rows[0]
-			configuration = adminPortal.Configuration
+			configuration = &adminPortal.Configuration
+		default:
+			return diag.FromErr(fmt.Errorf("Too many admin portals!"))
 		}
 
 		configuration.Navigation.Account = serializeVisibility("admin_portal.0.enable_account_settings")


### PR DESCRIPTION
`configuration` should be a reference to the `adminPortal.Configuration` not a value itself. 


### Purpose:

**Fixes Erroneous Behavior.**

Because configuration here is not a reference to adminPortal.Configuration it is updating the configuration variable but not the adminPortal object which is posted to `metadata?entityName=adminBox` this means the admin portal is not being updated correctly during workspace update. 

### How it was tested.
Attempted to make multiple navigation updates with and without this value as a reference, this change worked, without this change it did not work. 



