### PR TITLE
Support setting metadata in the Frontegg Tenant Resource

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -23,6 +23,7 @@ Configures a Frontegg tenant.
 ### Optional
 
 - `application_uri` (String) The application URI for this tenant.
+- `desired_metadata` (Map of String) Metadata to set and manage; will be merged with upstream metadata fields set outside of terraform.
 
 ### Read-Only
 

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -23,7 +23,7 @@ Configures a Frontegg tenant.
 ### Optional
 
 - `application_uri` (String) The application URI for this tenant.
-- `desired_metadata` (Map of String) Metadata to set and manage; will be merged with upstream metadata fields set outside of terraform.
+- `selected_metadata` (Map of String) Metadata to set and manage; will be merged with upstream metadata fields set outside of terraform.
 
 ### Read-Only
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -207,11 +207,11 @@ resource "frontegg_role" "example" {
 }
 
 resource "frontegg_tenant" "example" {
-  name    = "Example"
-  key     = "fake-tenant-id"
+  name = "Example"
+  key  = "example-tenant-id"
 
-  desired_metadata = {
-    "test_key_1": "value_3",
+  selected_metadata = {
+    "selected_metadata_key" : "selected_metadata_value",
   }
 }
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -206,6 +206,15 @@ resource "frontegg_role" "example" {
   ]
 }
 
+resource "frontegg_tenant" "example" {
+  name    = "Example"
+  key     = "fake-tenant-id"
+
+  desired_metadata = {
+    "test_key_1": "value_3",
+  }
+}
+
 output "public_key" {
   value = resource.frontegg_workspace.example.auth_policy.0.jwt_public_key
 }

--- a/provider/util.go
+++ b/provider/util.go
@@ -11,3 +11,11 @@ func stringSetToList(set *schema.Set) []string {
 	}
 	return out
 }
+
+func castResourceStringMap(resourceMapValue interface{}) map[string]string {
+	newStringMap := make(map[string]string)
+	for key, val := range resourceMapValue.(map[string]interface{}) {
+		newStringMap[key] = val.(string)
+	}
+	return newStringMap
+}


### PR DESCRIPTION
This adds support for a `desired_metadata` field to Frontegg Tenant Resource. This is named as-so because this field is merged into the upstream `metadata` on the Tenant to avoid overwriting any other metadata set on the Tenant by other tools (a use-case we have at Materialize).

This uses the Set Tenant Metadata and Delete Tenant Metadata APIs to set and remove metadata fields by key:
https://docs.frontegg.com/reference/tenantcontrollerv1_settenantmetadata
https://docs.frontegg.com/reference/tenantcontrollerv1_deletetenantmetadata

It also deserializes the json-ified `metadata` string returned from the Get Tenant API but only stores values for the specific keys already present in `desired_metadata` in the terraform state. Therefore the provider only reports changes to those specific keys, and not any others managed outside of terraform.


I tested this using the basic example and validating the Create, Update, Delete of various keys in the metadata, as well as ensuring that separate metadata keys introduced via the Frontegg UI were left alone by the provider.