### PR TITLE
Fix for frontegg_tenant deserialization when upstream tenant metadata keys contian non-string values

### DIFF
--- a/provider/resource_frontegg_tenant.go
+++ b/provider/resource_frontegg_tenant.go
@@ -98,13 +98,18 @@ func resourceFronteggTenantDeserialize(d *schema.ResourceData, f fronteggTenant)
 func resourceFronteggTenantMetadataDeserialize(d *schema.ResourceData, metadata string) error {
 	// We only manage keys that are explicitly selected.
 	selectedMetadata := castResourceStringMap(d.Get("selected_metadata"))
-	var allUpstreamMetadata map[string]string
+	var allUpstreamMetadata map[string]interface{}
 	if err := json.Unmarshal([]byte(metadata), &allUpstreamMetadata); err != nil {
 		return err
 	}
 	for key := range selectedMetadata {
 		if newValue, ok := allUpstreamMetadata[key]; ok {
-			selectedMetadata[key] = newValue
+			// All metadata keys managed by this provider must use string values
+			// so ignore the upstream value if it is not a string
+			newValueString, ok := newValue.(string)
+			if ok {
+				selectedMetadata[key] = newValueString
+			}
 		} else {
 			delete(selectedMetadata, key)
 		}


### PR DESCRIPTION
This fixes a bug in the new support for setting metadata on the tenant resource introduced in https://github.com/frontegg/terraform-provider-frontegg/pull/123

If other metadata already existed on the resource that contained non-string values, the provider would throw an error when attempting to deserialize the metadata field returned from the frontegg api:
```
json: cannot unmarshal bool into Go value of type string
```

Long-term it would be better to add support for setting and updating non-string values in the `selected_metadata` field, but as this is currently breaking our deployment infra we are opting for a quicker fix to ensure that the provider does not error when encountering this scenario.