### PR TITLE
Ignore 404s

### DIFF
--- a/provider/resource_frontegg_webhook.go
+++ b/provider/resource_frontegg_webhook.go
@@ -206,8 +206,12 @@ func resourceFronteggWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceFronteggWebhookDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientHolder := meta.(*restclient.ClientHolder)
-	if err := clientHolder.PortalClient.Delete(ctx, fmt.Sprintf("%s/%s", fronteggWebhookPath, d.Id()), nil); err != nil {
+	err := clientHolder.PortalClient.Delete(ctx, fmt.Sprintf("%s/%s", fronteggWebhookPath, d.Id()), nil)
+
+	// Handle non-404 errors
+	if err != nil && !restclient.IsNotFound(err) {
 		return diag.FromErr(err)
 	}
+
 	return nil
 }

--- a/provider/resource_frontegg_webhook.go
+++ b/provider/resource_frontegg_webhook.go
@@ -206,10 +206,15 @@ func resourceFronteggWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceFronteggWebhookDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientHolder := meta.(*restclient.ClientHolder)
+
+	// Configure the client to ignore 404 errors
+	clientHolder.ApiClient.Ignore404()
+
+	// Attempt to delete the webhook
 	err := clientHolder.PortalClient.Delete(ctx, fmt.Sprintf("%s/%s", fronteggWebhookPath, d.Id()), nil)
 
-	// Handle non-404 errors
-	if err != nil && !restclient.IsNotFound(err) {
+	// Handle errors other than 404
+	if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/provider/resource_frontegg_webhook.go
+++ b/provider/resource_frontegg_webhook.go
@@ -208,7 +208,7 @@ func resourceFronteggWebhookDelete(ctx context.Context, d *schema.ResourceData, 
 	clientHolder := meta.(*restclient.ClientHolder)
 
 	// Configure the client to ignore 404 errors
-	clientHolder.ApiClient.Ignore404()
+	clientHolder.PortalClient.Ignore404()
 
 	// Attempt to delete the webhook
 	err := clientHolder.PortalClient.Delete(ctx, fmt.Sprintf("%s/%s", fronteggWebhookPath, d.Id()), nil)


### PR DESCRIPTION
In the original code, if the Delete function returns any error, this error is immediately returned, which has caused us problems as it includes the case where the error is a 404 (resource not found). This is the expected scenario when the resource is already deleted.

The change updates error handling to specifically check if the error is not a 404. If the error is anything other than a 404, it's returned. Should also allow adding additional error-handling cases in the future.