### PR TITLE
fix custom_domain domain missing issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 )
 
@@ -38,7 +39,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.19.0 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.19.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.2 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/provider/resource_frontegg_user.go
+++ b/provider/resource_frontegg_user.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
@@ -92,7 +92,7 @@ func resourceFronteggUser() *schema.Resource {
 }
 
 func resourceFronteggUserSerialize(d *schema.ResourceData) fronteggUser {
-	log.Printf("role IDs: %#v", d.Get("role_ids").(*schema.Set).List())
+	slog.Debug("role IDs: %#v", d.Get("role_ids").(*schema.Set).List())
 	return fronteggUser{
 		Email:           d.Get("email").(string),
 		Password:        d.Get("password").(string),


### PR DESCRIPTION
        - checks for domain missing in retry loop
        - moves logging to tflog/slog where possible
        
        
        
 ```
    	* restclient: request failed: POST https://api.frontegg.com/vendors/custom-domains/verify: 404 Not Found: map[Cf-Cache-Status:[DYNAMIC] Cf-Ray:[8428a344dce59432-SJC] Content-Length:[39] Content-Security-Policy:[default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests] Content-Type:[application/json; charset=utf-8] Cross-Origin-Embedder-Policy:[require-corp] Cross-Origin-Opener-Policy:[same-origin] Cross-Origin-Resource-Policy:[same-origin] Date:[Tue, 09 Jan 2024 00:41:59 GMT] Frontegg-Trace-Id:[df41166e12da919e6b52082b6660e414] Origin-Agent-Cluster:[?1] Referrer-Policy:[no-referrer] Server:[cloudflare] Strict-Transport-Security:[max-age=15552000; includeSubDomains] X-Content-Type-Options:[nosniff] X-Dns-Prefetch-Control:[off] X-Download-Options:[noopen] X-Frame-Options:[SAMEORIGIN] X-Permitted-Cross-Domain-Policies:[none] X-Xss-Protection:[0]]: {"errors":["Custom domain is missing"]}
 ```
 
 I suspect the only way to get into this loop is if the post to recreate (or initially create) the custom domain succeeded, which makes me think this may be some sort of consistency error that will be fixed by retry. 
 