### PR TITLE
FR-20801: Enhance email template schema with active status and update resource …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ website/vendor
 
 #local
 local
+terraform.tfstate*

--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -387,6 +387,12 @@ func resourceFronteggWorkspace() *schema.Resource {
 	resourceFronteggEmail := func() *schema.Resource {
 		return &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"active": {
+					Description: "Whether the email template is active.",
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     true,
+				},
 				"from_address": {
 					Description: `The address to use in the "From" header of the email.`,
 					Type:        schema.TypeString,
@@ -1455,6 +1461,7 @@ func resourceFronteggWorkspaceRead(ctx context.Context, d *schema.ResourceData, 
 					var items []interface{}
 					if t.Active {
 						items = append(items, map[string]interface{}{
+							"active":               t.Active,
 							"from_address":         t.SenderEmail,
 							"from_name":            t.FromName,
 							"subject":              t.Subject,
@@ -1938,7 +1945,7 @@ func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData
 			Type:        typ,
 		}
 		if len(email) > 0 {
-			in.Active = true
+			in.Active = d.Get(fmt.Sprintf("%s.0.active", field)).(bool)
 			in.FromName = d.Get(fmt.Sprintf("%s.0.from_name", field)).(string)
 			in.SenderEmail = d.Get(fmt.Sprintf("%s.0.from_address", field)).(string)
 			in.Subject = d.Get(fmt.Sprintf("%s.0.subject", field)).(string)


### PR DESCRIPTION
* Added 'active' field to the email template schema, allowing users to specify whether the template is active.
* Updated resource handling to correctly retrieve and set the 'active' status during workspace updates.
* Modified .gitignore to exclude Terraform state files.