### PR TITLE
Bump golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -26,7 +26,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v2.1.6
+          version: v2.11.4
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
## Summary
- Bump golangci-lint pinned in CI from v2.1.6 → v2.11.4

## Why
v2.1.6 is built with Go 1.24 and emits:
> can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.8)

…on any module that targets Go 1.25. This blocks the in-flight dependabot bumps:
- #232 terraform-plugin-docs v0.24 → v0.25 (pulls in `go 1.25.8`)
- #226 terraform-plugin-sdk v2.38.2 → v2.40.0 (also bumps to Go 1.25)

Bumping to v2.11.4 (latest) clears the lint blocker on both.

## Test plan
- [x] CI lint passes on this branch (no Go-version mismatch since master is still on Go 1.24, and 2.11.4 supports both)
- [x] After merge, trigger `@dependabot rebase` on #232 and #226 to pick up the new lint version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the pinned linter version in CI, though it may surface new/changed lint findings compared to the previous version.
> 
> **Overview**
> Bumps the golangci-lint version used by the GitHub Actions `golangci-lint` workflow from `v2.1.6` to `v2.11.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab08863f04ad4914839f0c7862caa368a5bc2c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->