### PR TITLE
FR-25165 Add 429 rate-limit handling to the REST client

### DIFF
--- a/internal/restclient/ratelimit.go
+++ b/internal/restclient/ratelimit.go
@@ -1,0 +1,200 @@
+package restclient
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	// rateLimitResetHeader is set by the Frontegg api-gateway as an RFC 3339
+	// date-time string indicating when the rate-limit window resets.
+	rateLimitResetHeader = "X-Rate-Limit-Reset"
+	// retryAfterHeader is parsed defensively. Frontegg does not send it today,
+	// but it is the HTTP-standard signal and may appear in the future.
+	retryAfterHeader = "Retry-After"
+
+	// defaultRateLimitWait is used when a 429 carries no usable wait header.
+	// This happens for upstream-proxied 429s, where the gateway strips the
+	// X-Rate-Limit-* headers.
+	defaultRateLimitWait = time.Minute
+
+	// rateLimitMaxAttempts and rateLimitMaxTotalWait are safety ceilings that
+	// only protect against a hang if the request context lacks a deadline.
+	// They are not reached under normal operation.
+	rateLimitMaxAttempts  = 100
+	rateLimitMaxTotalWait = time.Hour
+
+	// rateLimitJitter bounds the random-ish spread added on top of a computed
+	// wait so that many concurrent waiters on the same route do not all wake at
+	// the same instant and immediately re-trigger a 429. This is not backoff;
+	// the base wait is still the server-specified reset time.
+	rateLimitJitter = 2 * time.Second
+)
+
+// rateLimiter encapsulates all 429 / rate-limit policy: per-route memory of
+// when a route may next be retried, parsing of the rate-limit headers, the
+// wait computation (including jitter), and the safety ceilings. The REST client
+// owns HTTP mechanics and delegates rate-limit decisions here.
+//
+// It is held behind a pointer on Client so its mutex is never copied when a
+// Client value is copied (e.g. into ClientHolder).
+type rateLimiter struct {
+	mu       sync.Mutex
+	resetAt  map[string]time.Time
+	jitterIx int // advances per record to vary jitter without a clock/RNG
+
+	// Policy knobs. Defaults come from the package constants; tests override
+	// them to keep runs fast and to exercise the ceiling branch directly.
+	defaultWait  time.Duration
+	maxAttempts  int
+	maxTotalWait time.Duration
+	jitter       time.Duration
+}
+
+func newRateLimiter() *rateLimiter {
+	return &rateLimiter{
+		resetAt:      make(map[string]time.Time),
+		defaultWait:  defaultRateLimitWait,
+		maxAttempts:  rateLimitMaxAttempts,
+		maxTotalWait: rateLimitMaxTotalWait,
+		jitter:       rateLimitJitter,
+	}
+}
+
+// routeKey builds the per-route map key. The query string is stripped so
+// paginated reads do not fragment into many unrelated keys. Path params / IDs
+// are kept as-is (see story Known Limitations).
+func (rl *rateLimiter) routeKey(method, rawURL string) string {
+	path := rawURL
+	if u, err := url.Parse(rawURL); err == nil {
+		path = u.Path
+	}
+	return method + " " + path
+}
+
+// waitBeforeSend returns how long the caller must wait before sending to
+// routeKey (0 if the route is not currently rate-limited).
+func (rl *rateLimiter) waitBeforeSend(routeKey string, now time.Time) time.Duration {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	t, ok := rl.resetAt[routeKey]
+	if !ok {
+		return 0
+	}
+	if d := t.Sub(now); d > 0 {
+		return d
+	}
+	return 0
+}
+
+// onTooManyRequests is called after a 429. It computes how long this caller
+// should wait (header-derived or default, plus jitter), records the route's
+// reset time for other concurrent callers, and reports which header drove the
+// decision (for logging). The returned wait already includes the jitter so the
+// in-flight caller that sleeps it is de-synced from its peers (PERF-001).
+func (rl *rateLimiter) onTooManyRequests(routeKey string, h http.Header, now time.Time) (wait time.Duration, source string) {
+	base, source := rateLimitWaitFromHeaders(h, now, rl.defaultWait)
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.jitterIx++
+	wait = base + rl.jitterFor(rl.jitterIx)
+
+	resetAt := now.Add(wait)
+	// Keep the latest of any concurrently recorded value so two simultaneous
+	// 429s never shorten an already-recorded window.
+	if existing, ok := rl.resetAt[routeKey]; !ok || resetAt.After(existing) {
+		rl.resetAt[routeKey] = resetAt
+	}
+	return wait, source
+}
+
+// jitterFor returns a deterministic offset in [0, rl.jitter) derived from a
+// counter. No clock or RNG is used (both are unavailable here), yet consecutive
+// callers get different offsets, which is what spreads a concurrent herd.
+// Caller must hold rl.mu.
+func (rl *rateLimiter) jitterFor(ix int) time.Duration {
+	if rl.jitter <= 0 {
+		return 0
+	}
+	const jitterStep = 250 * time.Millisecond
+	return time.Duration(ix) * jitterStep % rl.jitter
+}
+
+// exceeded reports whether the safety ceiling has been reached. It is the only
+// loop exit other than a non-429 response and context cancellation.
+func (rl *rateLimiter) exceeded(attempts int, totalWait time.Duration) bool {
+	return attempts >= rl.maxAttempts || totalWait >= rl.maxTotalWait
+}
+
+// rateLimitWaitFromHeaders computes the base wait (no jitter) from the 429
+// response headers and reports the source. Priority: X-Rate-Limit-Reset
+// (RFC 3339) -> Retry-After (defensive) -> the provided default.
+func rateLimitWaitFromHeaders(h http.Header, now time.Time, def time.Duration) (time.Duration, string) {
+	if d, ok := parseRateLimitReset(h, now); ok {
+		return d, "x-rate-limit-reset"
+	}
+	if d, ok := parseRetryAfter(h, now); ok {
+		return d, "retry-after"
+	}
+	return def, "default"
+}
+
+// parseRateLimitReset parses the X-Rate-Limit-Reset header. The Frontegg
+// api-gateway sets it as an RFC 3339 date-time string (verified against
+// rate-limit.service.ts). It is never a number, so no numeric parsing.
+func parseRateLimitReset(h http.Header, now time.Time) (time.Duration, bool) {
+	v := h.Get(rateLimitResetHeader)
+	if v == "" {
+		return 0, false
+	}
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		return 0, false
+	}
+	d := t.Sub(now)
+	if d <= 0 {
+		return 0, false
+	}
+	return d, true
+}
+
+// parseRetryAfter parses the standard Retry-After header (integer seconds or an
+// HTTP-date). Defensive only: Frontegg does not send it today.
+func parseRetryAfter(h http.Header, now time.Time) (time.Duration, bool) {
+	v := h.Get(retryAfterHeader)
+	if v == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs <= 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		d := t.Sub(now)
+		if d <= 0 {
+			return 0, false
+		}
+		return d, true
+	}
+	return 0, false
+}
+
+// waitContext waits for d, returning early with the context error if ctx is
+// cancelled or its deadline passes first.
+func waitContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/restclient/restclient.go
+++ b/internal/restclient/restclient.go
@@ -141,11 +141,21 @@ func (c *Client) RequestWithHeaders(ctx context.Context, method string, url stri
 	for {
 		// Pre-send wait: if this route is known to be rate-limited, wait until
 		// its reset before sending. Re-check after each wait (TOCTOU) since
-		// another goroutine may push the reset further out.
+		// another goroutine may push the reset further out. These waits count
+		// toward the same safety ceiling as retries, so a route whose reset is
+		// continually pushed out by concurrent 429s cannot make a deadline-less
+		// request sleep forever.
 		for {
 			wait := c.rl.waitBeforeSend(routeKey, time.Now())
 			if wait <= 0 {
 				break
+			}
+			totalWait += wait
+			if c.rl.exceeded(attempts, totalWait) {
+				return fmt.Errorf(
+					"restclient: rate limited and gave up after %d attempts (%s total) waiting to send: %s %s%s",
+					attempts, totalWait, method, c.baseURL, url,
+				)
 			}
 			if err := waitContext(ctx, wait); err != nil {
 				return err

--- a/internal/restclient/restclient.go
+++ b/internal/restclient/restclient.go
@@ -150,7 +150,9 @@ func (c *Client) RequestWithHeaders(ctx context.Context, method string, url stri
 			if wait <= 0 {
 				break
 			}
-			totalWait += wait
+			// Give up only if the budget was ALREADY spent — a single pending
+			// reset is always waited out; the ceiling bounds repeated waits when
+			// concurrent 429s keep pushing the reset out on a deadline-less ctx.
 			if c.rl.exceeded(attempts, totalWait) {
 				return fmt.Errorf(
 					"restclient: rate limited and gave up after %d attempts (%s total) waiting to send: %s %s%s",
@@ -160,6 +162,7 @@ func (c *Client) RequestWithHeaders(ctx context.Context, method string, url stri
 			if err := waitContext(ctx, wait); err != nil {
 				return err
 			}
+			totalWait += wait
 		}
 
 		req, err := c.buildRequest(ctx, method, url, headers, body)
@@ -188,7 +191,9 @@ func (c *Client) RequestWithHeaders(ctx context.Context, method string, url stri
 			wait, source := c.rl.onTooManyRequests(routeKey, res.Header, time.Now())
 
 			attempts++
-			totalWait += wait
+			// Give up only if the budget was ALREADY spent by prior waits — not
+			// because this single wait would cross it. A lone reset window (even
+			// a long one) is always honored; the ceiling bounds repeated cycles.
 			if c.rl.exceeded(attempts, totalWait) {
 				return fmt.Errorf(
 					"restclient: rate limited and gave up after %d attempts (%s total): %s %s: %s: %v: %s",
@@ -202,6 +207,7 @@ func (c *Client) RequestWithHeaders(ctx context.Context, method string, url stri
 			if err := waitContext(ctx, wait); err != nil {
 				return err
 			}
+			totalWait += wait
 			continue
 		case res.StatusCode < 200 || res.StatusCode >= 300:
 			return fmt.Errorf(

--- a/internal/restclient/restclient.go
+++ b/internal/restclient/restclient.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"time"
 )
 
 type Client struct {
@@ -18,6 +19,7 @@ type Client struct {
 	ignore404           bool
 	environmentId       string
 	applicationId       string
+	rl                  *rateLimiter
 }
 
 func MakeRestClient(baseURL string, environmentId string, applicationId string) Client {
@@ -26,6 +28,7 @@ func MakeRestClient(baseURL string, environmentId string, applicationId string) 
 		baseURL:       baseURL,
 		environmentId: environmentId,
 		applicationId: applicationId,
+		rl:            newRateLimiter(),
 	}
 }
 
@@ -81,22 +84,17 @@ func (c *Client) Put(ctx context.Context, url string, in interface{}, out interf
 	return c.RequestWithHeaders(ctx, "PUT", url, nil, in, out)
 }
 
-func (c *Client) RequestWithHeaders(ctx context.Context, method string, url string, headers http.Header, in interface{}, out interface{}) error {
-	conflictRetryMethod := c.conflictRetryMethod
-	c.conflictRetryMethod = ""
-	ignore404 := c.ignore404
-	c.ignore404 = false
+// buildRequest constructs a fresh *http.Request for a single attempt. It is
+// called once per attempt because http.Request.Body is consumed by client.Do
+// and cannot be replayed.
+func (c *Client) buildRequest(ctx context.Context, method string, url string, headers http.Header, body []byte) (*http.Request, error) {
 	var reqBody io.Reader
-	if in != nil {
-		b, err := json.Marshal(in)
-		if err != nil {
-			return fmt.Errorf("restclient: failed to serialize JSON request: %w", err)
-		}
-		reqBody = bytes.NewBuffer(b)
+	if body != nil {
+		reqBody = bytes.NewReader(body)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+url, reqBody)
 	if err != nil {
-		return fmt.Errorf("restclient: failed to construct request: %w", err)
+		return nil, fmt.Errorf("restclient: failed to construct request: %w", err)
 	}
 	for k, vals := range headers {
 		for _, v := range vals {
@@ -113,30 +111,101 @@ func (c *Client) RequestWithHeaders(ctx context.Context, method string, url stri
 	if c.applicationId != "" {
 		req.Header.Set("frontegg-application-id", c.applicationId)
 	}
-	log.Printf("[TRACE] Sending request %+v", req)
-	res, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("restclient: failed sending request: %w", err)
-	}
-	resBody, err := io.ReadAll(res.Body)
-	if err != nil {
-		return fmt.Errorf("restclient: failed to read response: %w", err)
-	}
-	if res.StatusCode == 404 && ignore404 {
-		return nil
-	} else if res.StatusCode == 409 && conflictRetryMethod != "" {
-		return c.RequestWithHeaders(ctx, conflictRetryMethod, url, headers, in, out)
-	} else if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return fmt.Errorf(
-			"restclient: request failed: %s %s: %s: %v: %s",
-			req.Method, req.URL, res.Status, res.Header, resBody,
-		)
-	}
-	log.Printf("[TRACE] Received response data %q", string(resBody))
-	if out != nil {
-		if err := json.Unmarshal(resBody, out); err != nil {
-			return fmt.Errorf("restclient: failed to decode JSON response %#v: %w", string(resBody), err)
+	return req, nil
+}
+
+func (c *Client) RequestWithHeaders(ctx context.Context, method string, url string, headers http.Header, in interface{}, out interface{}) error {
+	// Capture the single-use flags once. They must be reused on every retry
+	// iteration below: the 429 retry is a loop (not recursion), so re-reading
+	// the struct fields would see them already zeroed and drop 409/404 behavior.
+	conflictRetryMethod := c.conflictRetryMethod
+	c.conflictRetryMethod = ""
+	ignore404 := c.ignore404
+	c.ignore404 = false
+
+	var body []byte
+	if in != nil {
+		b, err := json.Marshal(in)
+		if err != nil {
+			return fmt.Errorf("restclient: failed to serialize JSON request: %w", err)
 		}
+		body = b
 	}
-	return nil
+
+	routeKey := c.rl.routeKey(method, url)
+
+	var (
+		attempts  int
+		totalWait time.Duration
+	)
+	for {
+		// Pre-send wait: if this route is known to be rate-limited, wait until
+		// its reset before sending. Re-check after each wait (TOCTOU) since
+		// another goroutine may push the reset further out.
+		for {
+			wait := c.rl.waitBeforeSend(routeKey, time.Now())
+			if wait <= 0 {
+				break
+			}
+			if err := waitContext(ctx, wait); err != nil {
+				return err
+			}
+		}
+
+		req, err := c.buildRequest(ctx, method, url, headers, body)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[TRACE] Sending request %+v", req)
+		res, err := c.client.Do(req)
+		if err != nil {
+			return fmt.Errorf("restclient: failed sending request: %w", err)
+		}
+		resBody, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			return fmt.Errorf("restclient: failed to read response: %w", err)
+		}
+
+		switch {
+		case res.StatusCode == 404 && ignore404:
+			return nil
+		case res.StatusCode == 409 && conflictRetryMethod != "":
+			// Preserve existing behavior exactly: recurse with the swapped method.
+			return c.RequestWithHeaders(ctx, conflictRetryMethod, url, headers, in, out)
+		case res.StatusCode == http.StatusTooManyRequests:
+			wait, source := c.rl.onTooManyRequests(routeKey, res.Header, time.Now())
+
+			attempts++
+			totalWait += wait
+			if c.rl.exceeded(attempts, totalWait) {
+				return fmt.Errorf(
+					"restclient: rate limited and gave up after %d attempts (%s total): %s %s: %s: %v: %s",
+					attempts, totalWait, req.Method, req.URL, res.Status, res.Header, resBody,
+				)
+			}
+			log.Printf(
+				"[WARN] rate limited on %s; waiting %s (source: %s) before retry %d",
+				routeKey, wait, source, attempts,
+			)
+			if err := waitContext(ctx, wait); err != nil {
+				return err
+			}
+			continue
+		case res.StatusCode < 200 || res.StatusCode >= 300:
+			return fmt.Errorf(
+				"restclient: request failed: %s %s: %s: %v: %s",
+				req.Method, req.URL, res.Status, res.Header, resBody,
+			)
+		}
+
+		log.Printf("[TRACE] Received response data %q", string(resBody))
+		if out != nil {
+			if err := json.Unmarshal(resBody, out); err != nil {
+				return fmt.Errorf("restclient: failed to decode JSON response %#v: %w", string(resBody), err)
+			}
+		}
+		return nil
+	}
 }

--- a/internal/restclient/restclient_test.go
+++ b/internal/restclient/restclient_test.go
@@ -321,6 +321,39 @@ func TestSafetyCeilingTotalWait(t *testing.T) {
 	}
 }
 
+// TestPreSendWaitBoundedByCeiling verifies that the pre-send wait loop (entered
+// when a route is already known to be rate-limited) is bounded by the safety
+// ceiling, even with a deadline-less context and a reset that keeps being pushed
+// into the future. Addresses Cursor Bugbot "Pre-send wait bypasses ceilings".
+func TestPreSendWaitBoundedByCeiling(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.rl.defaultWait = 10 * time.Millisecond
+	c.rl.jitter = 0
+	c.rl.maxAttempts = 1000                   // attempts never increments here
+	c.rl.maxTotalWait = 50 * time.Millisecond // pre-send waits must hit this
+
+	// Seed the route as rate-limited far into the future so waitBeforeSend
+	// always returns a positive wait and the pre-send loop never naturally exits.
+	routeKey := c.rl.routeKey("GET", "/thing")
+	c.rl.resetAt[routeKey] = time.Now().Add(time.Hour)
+
+	// Background context (no deadline) — only the ceiling can stop this.
+	err := c.Get(context.Background(), "/thing", nil)
+	if err == nil || !strings.Contains(err.Error(), "gave up after") {
+		t.Fatalf("expected pre-send ceiling error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("request should never have been sent (stuck in pre-send wait), but server saw %d hits", got)
+	}
+}
+
 // TestContextStopsPersistent429 verifies that, with no ceiling reached, a
 // persistent 429 is still bounded by the request context.
 func TestContextStopsPersistent429(t *testing.T) {

--- a/internal/restclient/restclient_test.go
+++ b/internal/restclient/restclient_test.go
@@ -1,0 +1,546 @@
+package restclient
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestClient points a Client at a test server's URL and gives it an
+// authenticated token so the auth header path is exercised.
+func newTestClient(baseURL string) Client {
+	c := MakeRestClient(baseURL, "", "")
+	c.Authenticate("test-token")
+	return c
+}
+
+func TestParseRateLimitReset(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		value   string
+		wantOK  bool
+		wantDur time.Duration
+	}{
+		{"rfc3339 future", now.Add(30 * time.Second).Format(time.RFC3339), true, 30 * time.Second},
+		{"rfc3339 future with millis", now.Add(5 * time.Second).Format(time.RFC3339Nano), true, 5 * time.Second},
+		{"rfc3339 past", now.Add(-10 * time.Second).Format(time.RFC3339), false, 0},
+		{"empty", "", false, 0},
+		{"malformed", "not-a-date", false, 0},
+		{"numeric is rejected", "1750000000", false, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			if tc.value != "" {
+				h.Set(rateLimitResetHeader, tc.value)
+			}
+			d, ok := parseRateLimitReset(h, now)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && d != tc.wantDur {
+				t.Fatalf("dur = %v, want %v", d, tc.wantDur)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		value   string
+		wantOK  bool
+		wantDur time.Duration
+	}{
+		{"integer seconds", "5", true, 5 * time.Second},
+		{"zero seconds", "0", false, 0},
+		{"negative seconds", "-3", false, 0},
+		{"http-date future", now.Add(20 * time.Second).UTC().Format(http.TimeFormat), true, 20 * time.Second},
+		{"http-date past", now.Add(-20 * time.Second).UTC().Format(http.TimeFormat), false, 0},
+		{"empty", "", false, 0},
+		{"garbage", "soon", false, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			if tc.value != "" {
+				h.Set(retryAfterHeader, tc.value)
+			}
+			d, ok := parseRetryAfter(h, now)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && d != tc.wantDur {
+				t.Fatalf("dur = %v, want %v", d, tc.wantDur)
+			}
+		})
+	}
+}
+
+func TestRateLimitWaitPriority(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+
+	// Reset header wins over Retry-After.
+	h := http.Header{}
+	h.Set(rateLimitResetHeader, now.Add(30*time.Second).Format(time.RFC3339))
+	h.Set(retryAfterHeader, "5")
+	d, src := rateLimitWaitFromHeaders(h, now, defaultRateLimitWait)
+	if src != "x-rate-limit-reset" || d != 30*time.Second {
+		t.Fatalf("got (%v, %q), want (30s, x-rate-limit-reset)", d, src)
+	}
+
+	// No reset -> Retry-After.
+	h = http.Header{}
+	h.Set(retryAfterHeader, "5")
+	d, src = rateLimitWaitFromHeaders(h, now, defaultRateLimitWait)
+	if src != "retry-after" || d != 5*time.Second {
+		t.Fatalf("got (%v, %q), want (5s, retry-after)", d, src)
+	}
+
+	// No usable header -> default.
+	d, src = rateLimitWaitFromHeaders(http.Header{}, now, defaultRateLimitWait)
+	if src != "default" || d != defaultRateLimitWait {
+		t.Fatalf("got (%v, %q), want (%v, default)", d, src, defaultRateLimitWait)
+	}
+}
+
+// TestRetryAfter429ResetHeader verifies a 429 with X-Rate-Limit-Reset is waited
+// out and the request then succeeds.
+func TestRetryAfter429ResetHeader(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// 2s in the future; RFC3339 truncates sub-second, so the parsed
+			// wait is ~1–2s — safely above the measurable floor below.
+			w.Header().Set(rateLimitResetHeader, time.Now().Add(2*time.Second).UTC().Format(time.RFC3339))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	start := time.Now()
+	if err := c.Get(context.Background(), "/thing", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.OK {
+		t.Fatalf("response not decoded: %+v", out)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+	// Must have actually waited for the reset before retrying (not retried
+	// instantly). Lower bound is generous to tolerate RFC3339 truncation.
+	if time.Since(start) < 500*time.Millisecond {
+		t.Fatalf("expected to wait for reset, waited only %v", time.Since(start))
+	}
+}
+
+// TestRetryAfter429RetryAfterHeader verifies the defensive Retry-After path.
+func TestRetryAfter429RetryAfterHeader(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set(retryAfterHeader, "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	if err := c.Get(context.Background(), "/thing", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+}
+
+// TestRetry429PastResetUsesDefault verifies a 429 with no usable header falls
+// back to the default wait. We override nothing; instead the server sends a 429
+// with a past reset, then succeeds — the client must still recover. To keep the
+// test fast we use a context deadline shorter than the default and assert the
+// recovery happens only because the second attempt is allowed once the (past)
+// reset yields a zero pre-wait. So here we send NO header and expect a default
+// wait; we cap the test with a short-lived server response.
+func TestRetry429StrippedHeadersUsesDefault(t *testing.T) {
+	// Unit check: a 429 with no usable header must select the default source.
+	d, src := rateLimitWaitFromHeaders(http.Header{}, time.Now(), defaultRateLimitWait)
+	if src != "default" || d != defaultRateLimitWait {
+		t.Fatalf("stripped-header 429 should use default, got (%v, %q)", d, src)
+	}
+}
+
+// TestRetry429StrippedHeadersEndToEnd exercises the full retry path when the
+// gateway strips the X-Rate-Limit-* headers (upstream-proxied 429). The default
+// wait is shortened on the limiter so the test stays fast (TEST-002).
+func TestRetry429StrippedHeadersEndToEnd(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// No rate-limit headers at all.
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.rl.defaultWait = 100 * time.Millisecond
+	c.rl.jitter = 0
+	if err := c.Get(context.Background(), "/thing", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("expected 2 calls (429 then 200), got %d", calls)
+	}
+}
+
+// TestPostBodyReplayedOnRetry ensures the request body is present on attempt 2.
+func TestPostBodyReplayedOnRetry(t *testing.T) {
+	var calls int32
+	var bodies []string
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(b))
+		mu.Unlock()
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set(rateLimitResetHeader, time.Now().Add(500*time.Millisecond).UTC().Format(time.RFC3339))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	in := map[string]string{"name": "widget"}
+	if err := c.Post(context.Background(), "/things", in, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 bodies, got %d: %v", len(bodies), bodies)
+	}
+	for i, b := range bodies {
+		if !strings.Contains(b, `"name":"widget"`) {
+			t.Fatalf("attempt %d body missing payload: %q", i+1, b)
+		}
+	}
+}
+
+// TestContextCancelDuringWait verifies a cancelled context aborts the wait
+// promptly rather than blocking for the full reset duration.
+func TestContextCancelDuringWait(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always 429 with a long reset so the client would otherwise wait.
+		w.Header().Set(rateLimitResetHeader, time.Now().Add(1*time.Hour).UTC().Format(time.RFC3339))
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := c.Get(ctx, "/thing", nil)
+	if err == nil {
+		t.Fatalf("expected context error, got nil")
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("wait did not abort on context cancel; took %v", time.Since(start))
+	}
+}
+
+// TestSafetyCeilingAttempts verifies the attempts ceiling fires and returns the
+// "gave up after N attempts" error — using a background context (no deadline)
+// so the ceiling, not the context, is what stops the loop (TEST-001).
+func TestSafetyCeilingAttempts(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	// Tiny waits + a low attempts ceiling so the branch is reached quickly.
+	c.rl.defaultWait = time.Millisecond
+	c.rl.jitter = 0
+	c.rl.maxAttempts = 3
+	c.rl.maxTotalWait = time.Hour // ensure the attempts ceiling wins
+
+	err := c.Get(context.Background(), "/thing", nil)
+	if err == nil || !strings.Contains(err.Error(), "gave up after") {
+		t.Fatalf("expected 'gave up after' ceiling error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected exactly maxAttempts (3) calls, got %d", got)
+	}
+}
+
+// TestSafetyCeilingTotalWait verifies the total-wait ceiling fires independently
+// of the attempts ceiling.
+func TestSafetyCeilingTotalWait(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.rl.defaultWait = 20 * time.Millisecond
+	c.rl.jitter = 0
+	c.rl.maxAttempts = 1000                   // do not let attempts win
+	c.rl.maxTotalWait = 60 * time.Millisecond // ~3 attempts worth
+
+	err := c.Get(context.Background(), "/thing", nil)
+	if err == nil || !strings.Contains(err.Error(), "gave up after") {
+		t.Fatalf("expected 'gave up after' ceiling error, got %v", err)
+	}
+}
+
+// TestContextStopsPersistent429 verifies that, with no ceiling reached, a
+// persistent 429 is still bounded by the request context.
+func TestContextStopsPersistent429(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(rateLimitResetHeader, time.Now().Add(50*time.Millisecond).UTC().Format(time.RFC3339))
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := c.Get(ctx, "/thing", nil)
+	if err == nil {
+		t.Fatalf("expected an error from persistent 429, got nil")
+	}
+}
+
+// Test409ConflictRetryPreserved verifies the existing 409 conflict-retry still
+// re-issues with the swapped method.
+func Test409ConflictRetryPreserved(t *testing.T) {
+	var methods []string
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		n := len(methods)
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.ConflictRetryMethod("PUT")
+	if err := c.Post(context.Background(), "/things", map[string]string{"a": "b"}, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(methods) != 2 || methods[0] != "POST" || methods[1] != "PUT" {
+		t.Fatalf("expected [POST PUT], got %v", methods)
+	}
+}
+
+// Test404IgnorePreserved verifies the existing 404-ignore still returns nil.
+func Test404IgnorePreserved(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.Ignore404()
+	if err := c.Get(context.Background(), "/missing", nil); err != nil {
+		t.Fatalf("expected nil for ignored 404, got %v", err)
+	}
+}
+
+// Test429Then409 verifies the captured conflict-retry flag still fires when a
+// 429 precedes a 409 (the flag must survive the 429 loop iterations).
+func Test429Then409(t *testing.T) {
+	var step int32
+	var mu sync.Mutex
+	var methods []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+		switch atomic.AddInt32(&step, 1) {
+		case 1:
+			w.Header().Set(rateLimitResetHeader, time.Now().Add(300*time.Millisecond).UTC().Format(time.RFC3339))
+			w.WriteHeader(http.StatusTooManyRequests)
+		case 2:
+			w.WriteHeader(http.StatusConflict)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.ConflictRetryMethod("PUT")
+	if err := c.Post(context.Background(), "/things", map[string]string{"a": "b"}, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	// POST (429) -> POST (409) -> PUT (200)
+	if len(methods) != 3 || methods[0] != "POST" || methods[1] != "POST" || methods[2] != "PUT" {
+		t.Fatalf("expected [POST POST PUT], got %v", methods)
+	}
+}
+
+// TestConcurrentSameRouteWaits exercises the per-route rate-limit map (the new
+// shared state added by this story) under -race. Each goroutine uses its own
+// Client value that shares one *rateLimitState, mirroring concurrent traffic
+// hitting the rate-limit memory. (Per-Client flag fields like
+// conflictRetryMethod are intentionally NOT shared here: that pre-existing
+// unguarded race is documented as out-of-scope, and callers serialize it.)
+func TestConcurrentSameRouteWaits(t *testing.T) {
+	var limitedHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/limited" {
+			// First hit 429s with a short reset; subsequent hits succeed.
+			if atomic.AddInt32(&limitedHits, 1) == 1 {
+				w.Header().Set(rateLimitResetHeader, time.Now().Add(300*time.Millisecond).UTC().Format(time.RFC3339))
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	shared := newRateLimiter()
+	newClient := func() Client {
+		c := newTestClient(srv.URL)
+		c.rl = shared
+		return c
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := newClient()
+			_ = c.Get(context.Background(), "/limited", nil)
+		}()
+	}
+	// Unrelated route must not be blocked by the limited route's reset.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := newClient()
+			if err := c.Get(context.Background(), "/other", nil); err != nil {
+				t.Errorf("unrelated route errored: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestRouteKeyStripsQuery(t *testing.T) {
+	rl := newRateLimiter()
+	got := rl.routeKey("GET", "/users?offset=10&limit=50")
+	want := "GET /users"
+	if got != want {
+		t.Fatalf("route key = %q, want %q", got, want)
+	}
+}
+
+// TestJitterAppliedToWait verifies the wait returned to the in-flight caller
+// includes jitter (PERF-001), so concurrent callers do not all wake at the same
+// instant. Consecutive onTooManyRequests calls with the same base must return
+// different waits.
+func TestJitterAppliedToWait(t *testing.T) {
+	rl := newRateLimiter()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	h := http.Header{} // no headers -> base = defaultWait
+
+	w1, _ := rl.onTooManyRequests("GET /a", h, now)
+	w2, _ := rl.onTooManyRequests("GET /b", h, now)
+
+	if w1 < rl.defaultWait || w2 < rl.defaultWait {
+		t.Fatalf("waits should be >= base default; got %v, %v", w1, w2)
+	}
+	if w1 >= rl.defaultWait+rl.jitter || w2 >= rl.defaultWait+rl.jitter {
+		t.Fatalf("waits should be < base+jitter; got %v, %v", w1, w2)
+	}
+	if w1 == w2 {
+		t.Fatalf("consecutive waits should differ due to jitter; both %v", w1)
+	}
+}
+
+// TestNoJitterWhenDisabled verifies jitter can be turned off (used by other
+// tests to get deterministic waits).
+func TestNoJitterWhenDisabled(t *testing.T) {
+	rl := newRateLimiter()
+	rl.jitter = 0
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	w, _ := rl.onTooManyRequests("GET /a", http.Header{}, now)
+	if w != rl.defaultWait {
+		t.Fatalf("with jitter disabled, wait should equal default %v, got %v", rl.defaultWait, w)
+	}
+}
+
+// TestNon429ErrorUnchanged verifies a generic non-2xx still returns the existing
+// formatted error and does not get swallowed by the 429 path.
+func TestNon429ErrorUnchanged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.Get(context.Background(), "/thing", nil)
+	if err == nil || !strings.Contains(err.Error(), "request failed") {
+		t.Fatalf("expected formatted request-failed error, got %v", err)
+	}
+}
+
+// sanity: ensure the example reset value format in the story parses.
+func TestStoryExampleResetParses(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	h := http.Header{}
+	h.Set(rateLimitResetHeader, "2026-06-07T12:34:56.789Z")
+	d, ok := parseRateLimitReset(h, now)
+	if !ok {
+		t.Fatalf("story example reset should parse")
+	}
+	if d <= 0 {
+		t.Fatalf("expected positive duration, got %v", d)
+	}
+	_ = fmt.Sprintf("%v", d)
+}

--- a/internal/restclient/restclient_test.go
+++ b/internal/restclient/restclient_test.go
@@ -321,10 +321,13 @@ func TestSafetyCeilingTotalWait(t *testing.T) {
 	}
 }
 
-// TestPreSendWaitBoundedByCeiling verifies that the pre-send wait loop (entered
-// when a route is already known to be rate-limited) is bounded by the safety
-// ceiling, even with a deadline-less context and a reset that keeps being pushed
-// into the future. Addresses Cursor Bugbot "Pre-send wait bypasses ceilings".
+// TestPreSendWaitBoundedByCeiling verifies that the pre-send wait loop is
+// bounded by the safety ceiling when a route's reset is CONTINUALLY pushed out
+// (the realistic concurrent-429 scenario) on a deadline-less context. A
+// background goroutine keeps bumping resetAt by a small amount, so each
+// waitBeforeSend returns a small wait; those accumulate and must eventually
+// trip the ceiling instead of looping forever.
+// Addresses Cursor Bugbot "Pre-send wait bypasses ceilings".
 func TestPreSendWaitBoundedByCeiling(t *testing.T) {
 	var hits int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -334,15 +337,36 @@ func TestPreSendWaitBoundedByCeiling(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	c.rl.defaultWait = 10 * time.Millisecond
 	c.rl.jitter = 0
-	c.rl.maxAttempts = 1000                   // attempts never increments here
-	c.rl.maxTotalWait = 50 * time.Millisecond // pre-send waits must hit this
+	c.rl.maxAttempts = 1000000 // attempts never increments in the pre-send loop
+	c.rl.maxTotalWait = 60 * time.Millisecond
 
-	// Seed the route as rate-limited far into the future so waitBeforeSend
-	// always returns a positive wait and the pre-send loop never naturally exits.
 	routeKey := c.rl.routeKey("GET", "/thing")
-	c.rl.resetAt[routeKey] = time.Now().Add(time.Hour)
+
+	// Seed before starting so the very first waitBeforeSend sees a positive wait
+	// (avoids a startup race where the loop exits before the bumper runs).
+	c.rl.mu.Lock()
+	c.rl.resetAt[routeKey] = time.Now().Add(50 * time.Millisecond)
+	c.rl.mu.Unlock()
+
+	// Continuously hold the route ~50ms in the future (tight loop, no gap) so
+	// every waitBeforeSend returns ~50ms and the pre-send loop never naturally
+	// exits. Two such waits (~100ms) exceed the 60ms budget, so the ceiling must
+	// trip rather than looping forever.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.rl.mu.Lock()
+				c.rl.resetAt[routeKey] = time.Now().Add(50 * time.Millisecond)
+				c.rl.mu.Unlock()
+			}
+		}
+	}()
+	defer close(stop)
 
 	// Background context (no deadline) — only the ceiling can stop this.
 	err := c.Get(context.Background(), "/thing", nil)
@@ -351,6 +375,37 @@ func TestPreSendWaitBoundedByCeiling(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&hits); got != 0 {
 		t.Fatalf("request should never have been sent (stuck in pre-send wait), but server saw %d hits", got)
+	}
+}
+
+// TestSingleLongResetIsHonored verifies the fix for Cursor Bugbot "Ceiling skips
+// wait entirely": a single 429 whose reset implies a wait near/over the budget
+// must still be waited out and retried — not rejected pre-emptively. Here one
+// reset (~30ms) exceeds maxTotalWait (20ms), yet the request must still succeed
+// after waiting, because the budget was not already spent.
+func TestSingleLongResetIsHonored(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set(rateLimitResetHeader, time.Now().Add(1*time.Second).UTC().Format(time.RFC3339))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.rl.jitter = 0
+	c.rl.maxTotalWait = 100 * time.Millisecond // smaller than the single ~1s reset wait
+
+	// Must succeed: the lone reset is honored even though its wait exceeds the
+	// (deliberately tiny) total budget, because no budget was spent beforehand.
+	if err := c.Get(context.Background(), "/thing", nil); err != nil {
+		t.Fatalf("single long reset should be waited out and succeed, got: %v", err)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("expected 429 then 200 (2 calls), got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## What

Makes the REST client handle HTTP **429 (Too Many Requests)**: it waits until the rate-limit window resets and retries, instead of failing the `terraform apply`.

## Behavior

- **Wait source priority:** `X-Rate-Limit-Reset` (RFC 3339 date — verified against the api-gateway source) → `Retry-After` (defensive; Frontegg does not send it today) → **1-minute default** (used when an upstream-proxied 429 has its headers stripped).
- **Per-route memory:** keyed by `method + path` (query string stripped); a later call to a known-limited route waits before sending. Mutex-guarded, never sleeps holding the lock, TOCTOU re-check after waking.
- **Context-aware:** every wait aborts on `ctx` cancel/deadline — never sleeps past a Terraform operation timeout.
- **Safety ceiling:** 100 attempts or 1 hour total, then a clear error (guards against a hang on a deadline-less context).
- **Jitter** added to the slept wait so concurrent waiters on a route don't all wake at the same instant.

## Structure

Rate-limit policy is isolated in a new `internal/restclient/ratelimit.go` (`rateLimiter` type); `RequestWithHeaders` delegates to it and keeps the HTTP mechanics.

## Also fixed (pre-existing, in the request path)

- Request body is now replayed correctly on retry (was drained → empty body on a second attempt).
- `res.Body` is now closed on every attempt (was never closed).

## Existing behavior preserved

409 conflict-retry, 404-ignore, 2xx JSON decode, and all header injection are unchanged and regression-tested.

## Tests

- `go test -race ./internal/restclient/...` → 34 pass
- `go test ./...` → 71 pass across 4 packages
- `make lint` → pass
- `make testacc` not run locally (needs live credentials) — should run in CI.

Jira: FR-25165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the central HTTP client used by all provider resources; applies can block longer on rate limits (by design) but respect context deadlines and safety ceilings.
> 
> **Overview**
> Adds **automatic HTTP 429 handling** to the shared `internal/restclient` client so Terraform API calls wait and retry instead of failing immediately on rate limits.
> 
> A new **`rateLimiter`** (`ratelimit.go`) owns per-route reset memory (`method + path`, query stripped), header parsing (`X-Rate-Limit-Reset` → `Retry-After` → 1m default), jitter, and safety caps (100 attempts / 1h total wait). **`RequestWithHeaders`** now loops on 429 with context-aware waits, pre-send waits when a route is already limited, and preserves single-use **409** / **404** flags across retries.
> 
> The request path is refactored so each attempt builds a fresh request from a **marshaled body buffer** (fixes empty body on retry) and **closes** the response body every time.
> 
> Extensive tests cover headers, retries, ceilings, concurrency (`-race`), and regression for 409/404 and 429-then-409.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88b606bdadb9af20602e383aa388b9dbdc10bbe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->