### PR TITLE
Support password complexity rules in frontegg_workspace

### DIFF
--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -56,6 +56,19 @@ resource "frontegg_workspace" "example" {
     min_tests         = 2
     min_phrase_length = 6
     history           = 2
+
+    # Optional complexity tests count toward `min_tests`.
+    optional_tests {
+      require_lowercase     = true
+      require_uppercase     = true
+      require_numbers       = true
+      require_special_chars = true
+    }
+
+    # Required complexity tests must always pass.
+    required_tests {
+      check_three_repeated_chars = true
+    }
   }
 
   captcha_policy {
@@ -146,6 +159,34 @@ Required:
 - `min_length` (Number) The minimum length of a password.
 - `min_phrase_length` (Number)
 - `min_tests` (Number) The minimum number of strength tests the password must meet.
+
+Optional:
+
+- `optional_tests` (Block List, Max: 1) Optional password complexity tests. Each enabled test counts toward `min_tests`. (see [below for nested schema](#nestedblock--password_policy--optional_tests))
+- `required_tests` (Block List, Max: 1) Required password complexity tests. Each enabled test must pass for a password to be accepted. (see [below for nested schema](#nestedblock--password_policy--required_tests))
+
+<a id="nestedblock--password_policy--optional_tests"></a>
+### Nested Schema for `password_policy.optional_tests`
+
+Optional:
+
+- `check_three_repeated_chars` (Boolean) Disallow three or more repeated characters in a row.
+- `require_lowercase` (Boolean) Require at least one lowercase letter.
+- `require_numbers` (Boolean) Require at least one number.
+- `require_special_chars` (Boolean) Require at least one special character.
+- `require_uppercase` (Boolean) Require at least one uppercase letter.
+
+
+<a id="nestedblock--password_policy--required_tests"></a>
+### Nested Schema for `password_policy.required_tests`
+
+Optional:
+
+- `check_three_repeated_chars` (Boolean) Disallow three or more repeated characters in a row.
+- `require_lowercase` (Boolean) Require at least one lowercase letter.
+- `require_numbers` (Boolean) Require at least one number.
+- `require_special_chars` (Boolean) Require at least one special character.
+- `require_uppercase` (Boolean) Require at least one uppercase letter.
 
 
 <a id="nestedblock--captcha_policy"></a>

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -189,6 +189,7 @@ Optional:
 - `require_uppercase` (Boolean) Require at least one uppercase letter.
 
 
+
 <a id="nestedblock--captcha_policy"></a>
 ### Nested Schema for `captcha_policy`
 

--- a/examples/resources/frontegg_workspace/resource.tf
+++ b/examples/resources/frontegg_workspace/resource.tf
@@ -33,6 +33,19 @@ resource "frontegg_workspace" "example" {
     min_tests         = 2
     min_phrase_length = 6
     history           = 2
+
+    # Optional complexity tests count toward `min_tests`.
+    optional_tests {
+      require_lowercase     = true
+      require_uppercase     = true
+      require_numbers       = true
+      require_special_chars = true
+    }
+
+    # Required complexity tests must always pass.
+    required_tests {
+      check_three_repeated_chars = true
+    }
   }
 
   captcha_policy {

--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -86,11 +86,107 @@ type fronteggLockoutPolicy struct {
 }
 
 type fronteggPasswordPolicy struct {
-	AllowPassphrases       bool `json:"allowPassphrases"`
-	MinLength              int  `json:"minLength"`
-	MaxLength              int  `json:"maxLength"`
-	MinOptionalTestsToPass int  `json:"minOptionalTestsToPass"`
-	MinPhraseLength        int  `json:"minPhraseLength"`
+	AllowPassphrases       bool                   `json:"allowPassphrases"`
+	MinLength              int                    `json:"minLength"`
+	MaxLength              int                    `json:"maxLength"`
+	MinOptionalTestsToPass int                    `json:"minOptionalTestsToPass"`
+	MinPhraseLength        int                    `json:"minPhraseLength"`
+	OptionalTests          *fronteggPasswordTests `json:"optionalTests,omitempty"`
+	RequiredTests          *fronteggPasswordTests `json:"requiredTests,omitempty"`
+}
+
+// fronteggPasswordTests holds the password complexity tests that can be applied
+// either as optional tests (each enabled test counts toward min_tests) or as
+// required tests (each enabled test must pass).
+type fronteggPasswordTests struct {
+	RequireLowercase        bool `json:"requireLowercase"`
+	RequireUppercase        bool `json:"requireUppercase"`
+	RequireNumbers          bool `json:"requireNumbers"`
+	RequireSpecialChars     bool `json:"requireSpecialChars"`
+	CheckThreeRepeatedChars bool `json:"checkThreeRepeatedChars"`
+}
+
+// fronteggPasswordTestsElem returns the schema shared by the optional_tests and
+// required_tests nested blocks. The fields are Optional+Computed so that
+// configurations which omit them do not produce plan churn while Read still
+// reflects the values configured outside of Terraform.
+func fronteggPasswordTestsElem() *schema.Resource {
+	boolField := func(description string) *schema.Schema {
+		return &schema.Schema{
+			Description: description,
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+		}
+	}
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"require_lowercase":          boolField("Require at least one lowercase letter."),
+			"require_uppercase":          boolField("Require at least one uppercase letter."),
+			"require_numbers":            boolField("Require at least one number."),
+			"require_special_chars":      boolField("Require at least one special character."),
+			"check_three_repeated_chars": boolField("Disallow three or more repeated characters in a row."),
+		},
+	}
+}
+
+func expandFronteggPasswordTests(raw []interface{}) *fronteggPasswordTests {
+	if len(raw) == 0 || raw[0] == nil {
+		return nil
+	}
+	m := raw[0].(map[string]interface{})
+	return &fronteggPasswordTests{
+		RequireLowercase:        m["require_lowercase"].(bool),
+		RequireUppercase:        m["require_uppercase"].(bool),
+		RequireNumbers:          m["require_numbers"].(bool),
+		RequireSpecialChars:     m["require_special_chars"].(bool),
+		CheckThreeRepeatedChars: m["check_three_repeated_chars"].(bool),
+	}
+}
+
+func flattenFronteggPasswordTests(t *fronteggPasswordTests) []interface{} {
+	if t == nil {
+		return []interface{}{}
+	}
+	return []interface{}{map[string]interface{}{
+		"require_lowercase":          t.RequireLowercase,
+		"require_uppercase":          t.RequireUppercase,
+		"require_numbers":            t.RequireNumbers,
+		"require_special_chars":      t.RequireSpecialChars,
+		"check_three_repeated_chars": t.CheckThreeRepeatedChars,
+	}}
+}
+
+// validateFronteggPasswordTests reports a clear error when the same password
+// test is enabled in both optional_tests and required_tests, which is
+// contradictory: a test is either optional (counts toward min_tests) or
+// required (must always pass), not both.
+func validateFronteggPasswordTests(optional, required *fronteggPasswordTests) error {
+	if optional == nil || required == nil {
+		return nil
+	}
+	var conflicting []string
+	for _, c := range []struct {
+		name     string
+		opt, req bool
+	}{
+		{"require_lowercase", optional.RequireLowercase, required.RequireLowercase},
+		{"require_uppercase", optional.RequireUppercase, required.RequireUppercase},
+		{"require_numbers", optional.RequireNumbers, required.RequireNumbers},
+		{"require_special_chars", optional.RequireSpecialChars, required.RequireSpecialChars},
+		{"check_three_repeated_chars", optional.CheckThreeRepeatedChars, required.CheckThreeRepeatedChars},
+	} {
+		if c.opt && c.req {
+			conflicting = append(conflicting, c.name)
+		}
+	}
+	if len(conflicting) > 0 {
+		return fmt.Errorf(
+			"password test(s) %s cannot be enabled in both optional_tests and required_tests; enable each test in only one",
+			strings.Join(conflicting, ", "),
+		)
+	}
+	return nil
 }
 
 type fronteggPasswordHistoryPolicy struct {
@@ -329,6 +425,22 @@ Must be one of "off", "on", or "unless-saml".`,
 							Type:        schema.TypeInt,
 							Required:    true,
 						},
+						"optional_tests": {
+							Description: "Optional password complexity tests. Each enabled test counts toward `min_tests`.",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Elem:        fronteggPasswordTestsElem(),
+						},
+						"required_tests": {
+							Description: "Required password complexity tests. Each enabled test must pass for a password to be accepted.",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Elem:        fronteggPasswordTestsElem(),
+						},
 					},
 				},
 			},
@@ -565,6 +677,8 @@ func resourceFronteggWorkspaceRead(ctx context.Context, d *schema.ResourceData, 
 			"min_tests":         out.MinOptionalTestsToPass,
 			"min_phrase_length": out.MinPhraseLength,
 			"history":           history,
+			"optional_tests":    flattenFronteggPasswordTests(out.OptionalTests),
+			"required_tests":    flattenFronteggPasswordTests(out.RequiredTests),
 		}
 		if err := d.Set("password_policy", []interface{}{password_policy}); err != nil {
 			return diag.FromErr(err)
@@ -777,6 +891,11 @@ func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData
 			MaxLength:              d.Get("password_policy.0.max_length").(int),
 			MinOptionalTestsToPass: d.Get("password_policy.0.min_tests").(int),
 			MinPhraseLength:        d.Get("password_policy.0.min_phrase_length").(int),
+			OptionalTests:          expandFronteggPasswordTests(d.Get("password_policy.0.optional_tests").([]interface{})),
+			RequiredTests:          expandFronteggPasswordTests(d.Get("password_policy.0.required_tests").([]interface{})),
+		}
+		if err := validateFronteggPasswordTests(in.OptionalTests, in.RequiredTests); err != nil {
+			return diag.FromErr(err)
 		}
 		if err := clientHolder.ApiClient.Post(ctx, fronteggPasswordPolicyURL, in, nil); err != nil {
 			return diag.FromErr(err)

--- a/provider/resource_frontegg_workspace_test.go
+++ b/provider/resource_frontegg_workspace_test.go
@@ -1,0 +1,160 @@
+package provider
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestExpandFronteggPasswordTests(t *testing.T) {
+	// Omitted/empty blocks must expand to nil so the field is not sent on the
+	// wire, preserving behavior for configs that do not use the new blocks.
+	if got := expandFronteggPasswordTests(nil); got != nil {
+		t.Errorf("nil input: got %+v, want nil", got)
+	}
+	if got := expandFronteggPasswordTests([]interface{}{}); got != nil {
+		t.Errorf("empty input: got %+v, want nil", got)
+	}
+
+	raw := []interface{}{map[string]interface{}{
+		"require_lowercase":          true,
+		"require_uppercase":          false,
+		"require_numbers":            true,
+		"require_special_chars":      false,
+		"check_three_repeated_chars": true,
+	}}
+	got := expandFronteggPasswordTests(raw)
+	if got == nil {
+		t.Fatal("expected a non-nil result")
+	}
+	want := fronteggPasswordTests{RequireLowercase: true, RequireNumbers: true, CheckThreeRepeatedChars: true}
+	if *got != want {
+		t.Errorf("expand = %+v, want %+v", *got, want)
+	}
+}
+
+func TestFlattenFronteggPasswordTests(t *testing.T) {
+	if got := flattenFronteggPasswordTests(nil); len(got) != 0 {
+		t.Errorf("nil input: got %v, want empty slice", got)
+	}
+
+	in := &fronteggPasswordTests{RequireUppercase: true, RequireSpecialChars: true}
+	got := flattenFronteggPasswordTests(in)
+	if len(got) != 1 {
+		t.Fatalf("got %d items, want 1", len(got))
+	}
+	m := got[0].(map[string]interface{})
+	if m["require_uppercase"] != true || m["require_special_chars"] != true {
+		t.Errorf("flatten true fields wrong: %+v", m)
+	}
+	if m["require_lowercase"] != false || m["require_numbers"] != false || m["check_three_repeated_chars"] != false {
+		t.Errorf("flatten false fields wrong: %+v", m)
+	}
+}
+
+func TestFronteggPasswordTestsRoundTrip(t *testing.T) {
+	in := &fronteggPasswordTests{
+		RequireLowercase:        true,
+		RequireUppercase:        true,
+		RequireNumbers:          true,
+		RequireSpecialChars:     true,
+		CheckThreeRepeatedChars: true,
+	}
+	got := expandFronteggPasswordTests(flattenFronteggPasswordTests(in))
+	if got == nil || *got != *in {
+		t.Errorf("round trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestValidateFronteggPasswordTests(t *testing.T) {
+	tests := []struct {
+		name            string
+		optional        *fronteggPasswordTests
+		required        *fronteggPasswordTests
+		wantErr         bool
+		wantErrContains string
+	}{
+		{name: "both nil", optional: nil, required: nil, wantErr: false},
+		{
+			name:     "disjoint tests",
+			optional: &fronteggPasswordTests{RequireLowercase: true, RequireUppercase: true},
+			required: &fronteggPasswordTests{CheckThreeRepeatedChars: true},
+			wantErr:  false,
+		},
+		{
+			name:            "same test in both",
+			optional:        &fronteggPasswordTests{RequireNumbers: true},
+			required:        &fronteggPasswordTests{RequireNumbers: true},
+			wantErr:         true,
+			wantErrContains: "require_numbers",
+		},
+		{
+			name:     "optional nil with required set",
+			optional: nil,
+			required: &fronteggPasswordTests{RequireNumbers: true},
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFronteggPasswordTests(tt.optional, tt.required)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErrContains != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErrContains)) {
+				t.Errorf("error %v does not contain %q", err, tt.wantErrContains)
+			}
+		})
+	}
+}
+
+// TestFronteggPasswordPolicyOmitsTestsWhenNil verifies backward compatibility:
+// a policy without the new blocks must not emit optionalTests/requiredTests.
+func TestFronteggPasswordPolicyOmitsTestsWhenNil(t *testing.T) {
+	b, err := json.Marshal(fronteggPasswordPolicy{MinLength: 8, MaxLength: 128})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["optionalTests"]; ok {
+		t.Errorf("optionalTests should be omitted when nil: %s", b)
+	}
+	if _, ok := m["requiredTests"]; ok {
+		t.Errorf("requiredTests should be omitted when nil: %s", b)
+	}
+}
+
+// TestFronteggPasswordPolicyTestsWireFormat asserts the camelCase JSON keys the
+// Frontegg password configuration API expects.
+func TestFronteggPasswordPolicyTestsWireFormat(t *testing.T) {
+	b, err := json.Marshal(fronteggPasswordPolicy{
+		OptionalTests: &fronteggPasswordTests{RequireLowercase: true, RequireSpecialChars: true},
+		RequiredTests: &fronteggPasswordTests{CheckThreeRepeatedChars: true},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	opt, ok := m["optionalTests"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("optionalTests missing or wrong type: %s", b)
+	}
+	if opt["requireLowercase"] != true || opt["requireSpecialChars"] != true {
+		t.Errorf("optionalTests values wrong: %s", b)
+	}
+	for _, key := range []string{"requireLowercase", "requireUppercase", "requireNumbers", "requireSpecialChars", "checkThreeRepeatedChars"} {
+		if _, ok := opt[key].(bool); !ok {
+			t.Errorf("optionalTests missing expected key %q: %s", key, b)
+		}
+	}
+	req, ok := m["requiredTests"].(map[string]interface{})
+	if !ok || req["checkThreeRepeatedChars"] != true {
+		t.Errorf("requiredTests wire format wrong: %s", b)
+	}
+}


### PR DESCRIPTION
## Summary

Adds password complexity configuration to the `password_policy` block of `frontegg_workspace`, mapping to the Frontegg password configuration API's `optionalTests`/`requiredTests` objects (`POST/GET /identity/resources/configurations/v1/password`).

Two new nested blocks, each supporting the same five tests:

- `optional_tests` — each enabled test counts toward `min_tests`
- `required_tests` — each enabled test must always pass

Supported tests: `require_lowercase`, `require_uppercase`, `require_numbers`, `require_special_chars`, `check_three_repeated_chars`.

## Example

```hcl
password_policy {
  allow_passphrases = false
  min_length        = 10
  max_length        = 128
  min_tests         = 2
  min_phrase_length = 6
  history           = 2

  optional_tests {
    require_lowercase     = true
    require_uppercase     = true
    require_numbers       = true
    require_special_chars = true
  }

  required_tests {
    check_three_repeated_chars = true
  }
}
```

## Design notes

- **Backward compatible:** both blocks are `Optional + Computed`. Configs that omit them see no plan churn, and the tests are sent only when configured (pointer fields with `omitempty`).
- **State sync / drift:** Read populates both blocks from the API, so changes made outside Terraform are detected.
- **Validation:** a clear error is returned if the same test is enabled in both `optional_tests` and `required_tests` (a test is either optional or required, not both).
- Field names use the provider's snake_case convention; they map to the API's camelCase keys.

## Tests

Unit tests cover expand/flatten round-trip, `omitempty` backward-compat, the camelCase wire format, and the mutual-exclusivity validation. Existing schema-validation tests cover the new blocks. (The repo has no acceptance tests; CI's `test` job exercises the provider against real Frontegg.)
