### PR TITLE
FR-25244: Document allow_unverified_users as the email verification control

### DIFF
--- a/docs/resources/auth_policy.md
+++ b/docs/resources/auth_policy.md
@@ -43,7 +43,7 @@ resource "frontegg_auth_policy" "example" {
 
 - `allow_signups` (Boolean) Whether users are allowed to sign up.
 - `allow_tenant_invitations` (Boolean) Allow tenants to invite new users via an invitation link.
-- `allow_unverified_users` (Boolean) Whether unverified users are allowed to log in.
+- `allow_unverified_users` (Boolean) Whether unverified users are allowed to log in. This is the email verification control: set to `false` to require email verification (a verification link is sent to the user's email and they must verify before they can log in); set to `true` to allow login without verifying the email.
 - `auth_strategy` (String) The authentication strategy to use for people logging in.
 
 Must be one of "EmailAndPassword", "Code", "MagicLink", "NoLocalAuthentication", "SmsCode"

--- a/provider/resource_frontegg_auth_policy.go
+++ b/provider/resource_frontegg_auth_policy.go
@@ -47,9 +47,11 @@ per Frontegg provider.
 
 		Schema: map[string]*schema.Schema{
 			"allow_unverified_users": {
-				Description: "Whether unverified users are allowed to log in.",
-				Type:        schema.TypeBool,
-				Required:    true,
+				Description: "Whether unverified users are allowed to log in. This is the email verification control: " +
+					"set to `false` to require email verification (a verification link is sent to the user's email " +
+					"and they must verify before they can log in); set to `true` to allow login without verifying the email.",
+				Type:     schema.TypeBool,
+				Required: true,
 			},
 			"allow_signups": {
 				Description: "Whether users are allowed to sign up.",


### PR DESCRIPTION
## Context (FR-25244)
The ticket requested adding Terraform support for **email verification** settings, reporting that it "cannot be configured" and "reverts on every apply."

## Finding
Email verification **is already manageable** in the provider. The ticket's own API example (`{"allowNotVerifiedUsersLogin": false}` → `/identity/resources/configurations/v1`) maps to an existing attribute: **`frontegg_auth_policy.allow_unverified_users`**. Verified against the live API — the value round-trips correctly, and that endpoint **merges** (it does not wipe unmodeled fields), so there is no revert bug. The gap was **discoverability**: the attribute name doesn't say "email verification," so users assumed it was unsupported.

## Change
Docs-only: clarify the `allow_unverified_users` description so it's clear this is the email-verification control —
- `false` → require email verification (link sent, must verify before login)
- `true` → allow login without verifying the email

Example already includes the attribute. Regenerated `auth_policy.md`.

No code/behavior change, no new resource.