### PR TITLE
FR-25582 - Upgrade Go to 1.25.11 to fix stdlib CVEs in released binary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/frontegg/terraform-provider-frontegg
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0


### PR DESCRIPTION
## Context

A customer ran a [Trivy](https://github.com/aquasecurity/trivy) vulnerability scan against the published **v2.7.1** provider binary (the one they downloaded from the Terraform registry) and reported Go standard-library CVEs in it:

- `CVE-2025-68121` — **CRITICAL** (CVSS 9.1)
- 16 × **HIGH** stdlib CVEs

The `PACKAGE` was `stdlib` and `INSTALLED VERSION` was `v1.25.0` — i.e. the Go toolchain that compiled the binary.

## Root cause

v2.7.1 was built with **Go 1.25.0**. Those CVEs are in the Go runtime/standard library baked into the binary by the compiler, not in this repo's source. They are fixed by rebuilding with a patched Go toolchain.

## Fix

Bump the `go` directive in `go.mod` to **1.25.11** (latest 1.25.x patch).

No source code changes.

## Verification

Built the provider with each toolchain and scanned the binary with Trivy:

| Build Go | Customer's CVEs | Newer Go CVEs | Scan result |
|----------|-----------------|---------------|-------------|
| 1.25.0 (shipped v2.7.1) | 1 CRIT + 16 HIGH | — | reported |
| 1.25.8 (master before this PR) | cleared | 10 HIGH + 7 MEDIUM | still flags |
| **1.25.11 (this PR)** | cleared | none | **0 vulnerabilities** |

`go build ./...`, `go vet ./...`, and `gofmt` all pass.

## Behavior change risk

Very low. This is a Go **patch-level** bump within the same minor (1.25.x). Go's compatibility promise covers patch releases (security/bug fixes only — no API or language changes). No provider source changed.

## Scope

Go binary only. The `alpine` and `python-pkg` rows in the customer's scan come from **their** container base image, not our binary — out of scope for this repo.

## Follow-up

After merge, cut a **v2.7.2** release so customers can pin a patched provider.

FR-25582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level Go bump within 1.25.x with no source changes; risk is limited to rebuild/re-release alignment.
> 
> **Overview**
> Updates the **`go` directive in `go.mod` from 1.25.8 to 1.25.11** so released provider binaries are built with a patched Go standard library.
> 
> This addresses customer Trivy findings (including **CVE-2025-68121** and other stdlib issues) tied to older toolchains embedded in published artifacts such as v2.7.1. **No provider source or dependency changes**—only the compiler/runtime version used at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919eaca8f4a54436bb4eb091c053d92661fa4d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->