### PR TITLE
FR-25510: Preserve SAML IdP config when updating workspace saml block

### DIFF
--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -1002,17 +1002,35 @@ func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData
 
 	{
 		saml := d.Get("saml").([]interface{})
-		in := fronteggSSOSAML{
-			EntityName: "saml",
-		}
 		if len(saml) > 0 {
-			in.Configuration.ACSUrl = d.Get("saml.0.acs_url").(string)
-			in.Configuration.SPEntityID = d.Get("saml.0.sp_entity_id").(string)
-			in.Configuration.RedirectUrl = d.Get("saml.0.redirect_url").(string)
-			in.IsActive = true
-		}
-		if err := clientHolder.ApiClient.Post(ctx, fronteggSSOSAMLURL, in, nil); err != nil {
-			return diag.FromErr(err)
+			var existing struct {
+				Rows []struct {
+					Configuration map[string]interface{} `json:"configuration"`
+				} `json:"rows"`
+			}
+			if err := clientHolder.ApiClient.Get(ctx, fronteggSSOSAMLURL, &existing); err != nil {
+				return diag.FromErr(err)
+			}
+			configuration := map[string]interface{}{}
+			if len(existing.Rows) > 0 && existing.Rows[0].Configuration != nil {
+				configuration = existing.Rows[0].Configuration
+			}
+			configuration["acsUrl"] = d.Get("saml.0.acs_url").(string)
+			configuration["spEntityId"] = d.Get("saml.0.sp_entity_id").(string)
+			configuration["redirectUri"] = d.Get("saml.0.redirect_url").(string)
+			in := map[string]interface{}{
+				"entityName":    "saml",
+				"isActive":      true,
+				"configuration": configuration,
+			}
+			if err := clientHolder.ApiClient.Post(ctx, fronteggSSOSAMLURL, in, nil); err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			in := fronteggSSOSAML{EntityName: "saml"}
+			if err := clientHolder.ApiClient.Post(ctx, fronteggSSOSAMLURL, in, nil); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 	{

--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -786,6 +786,17 @@ func resourceFronteggWorkspaceRead(ctx context.Context, d *schema.ResourceData, 
 	return diag.Diagnostics{}
 }
 
+func mergeFronteggSAMLConfiguration(existing map[string]interface{}, acsURL, spEntityID, redirectURI string) map[string]interface{} {
+	configuration := map[string]interface{}{}
+	for key, value := range existing {
+		configuration[key] = value
+	}
+	configuration["acsUrl"] = acsURL
+	configuration["spEntityId"] = spEntityID
+	configuration["redirectUri"] = redirectURI
+	return configuration
+}
+
 func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientHolder := meta.(*restclient.ClientHolder)
 	{
@@ -1011,13 +1022,16 @@ func resourceFronteggWorkspaceUpdate(ctx context.Context, d *schema.ResourceData
 			if err := clientHolder.ApiClient.Get(ctx, fronteggSSOSAMLURL, &existing); err != nil {
 				return diag.FromErr(err)
 			}
-			configuration := map[string]interface{}{}
-			if len(existing.Rows) > 0 && existing.Rows[0].Configuration != nil {
-				configuration = existing.Rows[0].Configuration
+			var existingConfiguration map[string]interface{}
+			if len(existing.Rows) > 0 {
+				existingConfiguration = existing.Rows[0].Configuration
 			}
-			configuration["acsUrl"] = d.Get("saml.0.acs_url").(string)
-			configuration["spEntityId"] = d.Get("saml.0.sp_entity_id").(string)
-			configuration["redirectUri"] = d.Get("saml.0.redirect_url").(string)
+			configuration := mergeFronteggSAMLConfiguration(
+				existingConfiguration,
+				d.Get("saml.0.acs_url").(string),
+				d.Get("saml.0.sp_entity_id").(string),
+				d.Get("saml.0.redirect_url").(string),
+			)
 			in := map[string]interface{}{
 				"entityName":    "saml",
 				"isActive":      true,

--- a/provider/resource_frontegg_workspace_test.go
+++ b/provider/resource_frontegg_workspace_test.go
@@ -2,9 +2,47 @@ package provider
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestMergeFronteggSAMLConfiguration(t *testing.T) {
+	existing := map[string]interface{}{
+		"acsUrl":            "https://old.example.com/acs",
+		"spEntityId":        "old-sp",
+		"redirectUri":       "https://old.example.com/redirect",
+		"ssoEndpoint":       "https://idp.example.com/sso",
+		"publicCertificate": "CERT-DATA",
+		"type":              "saml",
+		"signRequest":       true,
+	}
+
+	got := mergeFronteggSAMLConfiguration(existing, "https://new.example.com/acs", "new-sp", "https://new.example.com/redirect")
+
+	want := map[string]interface{}{
+		"acsUrl":            "https://new.example.com/acs",
+		"spEntityId":        "new-sp",
+		"redirectUri":       "https://new.example.com/redirect",
+		"ssoEndpoint":       "https://idp.example.com/sso",
+		"publicCertificate": "CERT-DATA",
+		"type":              "saml",
+		"signRequest":       true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mergeFronteggSAMLConfiguration() = %#v, want %#v", got, want)
+	}
+
+	if existing["acsUrl"] != "https://old.example.com/acs" {
+		t.Errorf("input configuration was mutated: acsUrl = %v", existing["acsUrl"])
+	}
+
+	fromNil := mergeFronteggSAMLConfiguration(nil, "acs", "sp", "redirect")
+	wantFromNil := map[string]interface{}{"acsUrl": "acs", "spEntityId": "sp", "redirectUri": "redirect"}
+	if !reflect.DeepEqual(fromNil, wantFromNil) {
+		t.Errorf("mergeFronteggSAMLConfiguration(nil, ...) = %#v, want %#v", fromNil, wantFromNil)
+	}
+}
 
 func TestExpandFronteggPasswordTests(t *testing.T) {
 	// Omitted/empty blocks must expand to nil so the field is not sent on the


### PR DESCRIPTION
## Bug (FR-25510)
Modifying `redirect_url` in the `saml` block of `frontegg_workspace` does not take effect in the portal after `terraform apply` (reproduced internally).

## Root cause
The SAML metadata endpoint (`/metadata?entityName=saml`) does a **full replace**, but the workspace update POSTed only three fields — `acsUrl`, `spEntityId`, `redirectUri`. So any SAML configured in the portal (`publicCertificate`, `ssoEndpoint`, `type`, `signRequest`, …) was **wiped on every apply**, leaving an incomplete/invalid SAML config. The result the customer sees: the change doesn't "take" (the portal keeps the last valid config). Same lossy-partial-POST class as the admin-portal bug (#246).

Verified against a live env:
```
seeded config:  acsUrl, spEntityId, redirectUri, ssoEndpoint, publicCertificate, type, signRequest
old behavior — POST 3 fields → ssoEndpoint, publicCertificate, type, signRequest WIPED
```

## Fix
Preserve the existing SAML configuration: **GET** the current config, overlay only the three managed fields (`acs_url`, `sp_entity_id`, `redirect_url`), then **POST** the merged result.

## Verification (live API)
Replicated the new GET‑merge‑POST against a seeded IdP config:
- ✅ `ssoEndpoint`, `publicCertificate`, `type`, `signRequest` **preserved**
- ✅ `redirectUri` updates to the new value (patterns re-derived server-side)
- ✅ build / vet / gofmt / unit tests clean; env restored

## Note (out of scope)
When the `saml` block is **removed** from config, the update still POSTs an empty inactive config (unchanged pre-existing behavior). Preserving SAML for users who don't manage it in Terraform could be a follow-up.