### PR TITLE
Fix permanent drift in email template redirect URLs with template variables

### DIFF
--- a/provider/resource_frontegg_email_template.go
+++ b/provider/resource_frontegg_email_template.go
@@ -20,6 +20,12 @@ type fronteggEmailTemplateResource struct {
 	SenderEmail        string `json:"senderEmail"`
 	Subject            string `json:"subject"`
 	Type               string `json:"type"`
+
+	// The API renders template variables (e.g. "{{APP_ID}}") in redirectURL
+	// and successRedirectUrl in its responses, and returns the raw configured
+	// values in these read-only pattern fields.
+	RedirectURLPattern        string `json:"redirectURLPattern,omitempty"`
+	SuccessRedirectURLPattern string `json:"successRedirectUrlPattern,omitempty"`
 }
 
 func resourceFronteggEmailTemplate() *schema.Resource {
@@ -127,10 +133,21 @@ func resourceFronteggEmailTemplateDeserialize(d *schema.ResourceData, f frontegg
 		return err
 	}
 
-	if err := d.Set("redirect_url", f.RedirectURL); err != nil {
+	// Prefer the raw pattern fields: the API substitutes template variables
+	// (e.g. "{{APP_ID}}") in redirectURL and successRedirectUrl, which would
+	// produce a permanent diff for configurations that use such variables.
+	redirectURL := f.RedirectURL
+	if f.RedirectURLPattern != "" {
+		redirectURL = f.RedirectURLPattern
+	}
+	if err := d.Set("redirect_url", redirectURL); err != nil {
 		return err
 	}
-	if err := d.Set("success_redirect_url", f.SuccessRedirectURL); err != nil {
+	successRedirectURL := f.SuccessRedirectURL
+	if f.SuccessRedirectURLPattern != "" {
+		successRedirectURL = f.SuccessRedirectURLPattern
+	}
+	if err := d.Set("success_redirect_url", successRedirectURL); err != nil {
 		return err
 	}
 	return nil

--- a/provider/resource_frontegg_email_template_test.go
+++ b/provider/resource_frontegg_email_template_test.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestEmailTemplateDeserializePrefersPatternFields verifies that reading a
+// template prefers the raw redirectURLPattern/successRedirectUrlPattern fields
+// over the rendered redirectURL/successRedirectUrl fields, so configurations
+// using template variables (e.g. "{{APP_ID}}") don't produce a permanent diff.
+func TestEmailTemplateDeserializePrefersPatternFields(t *testing.T) {
+	tests := []struct {
+		name                   string
+		in                     fronteggEmailTemplateResource
+		wantRedirectURL        string
+		wantSuccessRedirectURL string
+	}{
+		{
+			name: "pattern fields present take precedence over rendered values",
+			in: fronteggEmailTemplateResource{
+				Type:                      "ActivateUser",
+				RedirectURL:               "https://example.com/activate?appId=",
+				RedirectURLPattern:        "https://example.com/activate?appId={{APP_ID}}",
+				SuccessRedirectURL:        "http://localhost:3000/",
+				SuccessRedirectURLPattern: "{{APP_URL}}",
+			},
+			wantRedirectURL:        "https://example.com/activate?appId={{APP_ID}}",
+			wantSuccessRedirectURL: "{{APP_URL}}",
+		},
+		{
+			name: "rendered values used when pattern fields are absent",
+			in: fronteggEmailTemplateResource{
+				Type:               "ResetPassword",
+				RedirectURL:        "https://example.com/reset-password",
+				SuccessRedirectURL: "https://example.com/done",
+			},
+			wantRedirectURL:        "https://example.com/reset-password",
+			wantSuccessRedirectURL: "https://example.com/done",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, resourceFronteggEmailTemplate().Schema, map[string]interface{}{})
+			if err := resourceFronteggEmailTemplateDeserialize(d, tt.in); err != nil {
+				t.Fatalf("resourceFronteggEmailTemplateDeserialize() error = %v", err)
+			}
+			if got := d.Get("redirect_url").(string); got != tt.wantRedirectURL {
+				t.Errorf("redirect_url = %q, want %q", got, tt.wantRedirectURL)
+			}
+			if got := d.Get("success_redirect_url").(string); got != tt.wantSuccessRedirectURL {
+				t.Errorf("success_redirect_url = %q, want %q", got, tt.wantSuccessRedirectURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #251.

## Problem

  Configuring `redirect_url` / `success_redirect_url` with template variables
  (e.g. `{{APP_ID}}`, `{{APP_URL}}`) produces a permanent diff: every plan wants
  to change the rendered value back to the configured one, even immediately
  after a successful apply.

## Root cause

  `GET /identity/resources/mail/v1/configs/templates` returns the **rendered**
  values in `redirectURL` / `successRedirectUrl` (variables substituted with the
  default-app context: `{{APP_ID}}` → empty string, `{{APP_URL}}` → the default
  application URL). The raw configured values are returned in separate fields
  `redirectURLPattern` / `successRedirectUrlPattern`, which the provider
  ignored. The write path is unaffected — the API stores the raw pattern
  correctly; only the read-back was wrong.

## Fix

  `resourceFronteggEmailTemplateDeserialize` now prefers `redirectURLPattern` /
  `successRedirectUrlPattern` when non-empty, falling back to the rendered
  fields — unchanged behavior for templates that don't use variables. The
  pattern fields are marked `omitempty` so create/update payloads are unchanged.

## Testing

  - New unit test `TestEmailTemplateDeserializePrefersPatternFields` covering
    both precedence and the fallback.
  - Verified against a live workspace: a configuration using
    `{{APP_ID}}`/`{{APP_URL}}` in three templates that previously re-planned the
    same 3 updates on every run now plans clean
    (`No changes. Your infrastructure matches the configuration.`).