### PR TITLE
Fix frontegg_webhook 401 by moving CRUD to the vendor API host

### DIFF
--- a/internal/restclient/clientholder.go
+++ b/internal/restclient/clientholder.go
@@ -3,4 +3,5 @@ package restclient
 type ClientHolder struct {
 	ApiClient    Client
 	PortalClient Client
+	VendorID     string
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -107,6 +107,7 @@ func New(version string) func() *schema.Provider {
 				applicationId := d.Get("application_id").(string)
 				apiClient := restclient.MakeRestClient(d.Get("api_base_url").(string), environmentId, applicationId)
 				portalClient := restclient.MakeRestClient(d.Get("portal_base_url").(string), environmentId, applicationId)
+				vendorId := d.Get("client_id").(string)
 				{
 					in := struct {
 						ClientId  string `json:"clientId"`
@@ -124,10 +125,14 @@ func New(version string) func() *schema.Provider {
 					}
 					portalClient.Authenticate(out.AccessToken)
 					apiClient.Authenticate(out.AccessToken)
+					if id, err := vendorIDFromToken(out.AccessToken); err == nil && id != "" {
+						vendorId = id
+					}
 				}
 				return &restclient.ClientHolder{
 					ApiClient:    apiClient,
 					PortalClient: portalClient,
+					VendorID:     vendorId,
 				}, nil
 			},
 		}

--- a/provider/resource_frontegg_webhook.go
+++ b/provider/resource_frontegg_webhook.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
@@ -12,6 +13,14 @@ import (
 )
 
 const fronteggWebhookPath = "/webhook"
+
+// The webhook routes are vendor-scoped on the API host and reject requests
+// without a tenant header, so every call sends the vendor ID as the tenant.
+func fronteggWebhookHeaders(clientHolder *restclient.ClientHolder) http.Header {
+	headers := http.Header{}
+	headers.Add("frontegg-tenant-id", clientHolder.VendorID)
+	return headers
+}
 
 type fronteggWebhook struct {
 	ID          string   `json:"_id,omitempty"`
@@ -145,7 +154,7 @@ func resourceFronteggWebhookCreate(ctx context.Context, d *schema.ResourceData, 
 	clientHolder := meta.(*restclient.ClientHolder)
 	in := resourceFronteggWebhookSerialize(d)
 	var out fronteggWebhook
-	if err := clientHolder.PortalClient.Post(ctx, fronteggWebhookPath+"/custom", in, &out); err != nil {
+	if err := clientHolder.ApiClient.PostWithHeaders(ctx, fronteggWebhookPath+"/custom", fronteggWebhookHeaders(clientHolder), in, &out); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := resourceFronteggWebhookDeserialize(d, out); err != nil {
@@ -157,7 +166,7 @@ func resourceFronteggWebhookCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceFronteggWebhookRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientHolder := meta.(*restclient.ClientHolder)
 	var out []fronteggWebhook
-	if err := clientHolder.PortalClient.Get(ctx, fronteggWebhookPath, &out); err != nil {
+	if err := clientHolder.ApiClient.GetWithHeaders(ctx, fronteggWebhookPath, fronteggWebhookHeaders(clientHolder), &out); err != nil {
 		return diag.FromErr(err)
 	}
 	for _, c := range out {
@@ -168,6 +177,7 @@ func resourceFronteggWebhookRead(ctx context.Context, d *schema.ResourceData, me
 			return diag.Diagnostics{}
 		}
 	}
+	d.SetId("")
 	return nil
 }
 
@@ -175,7 +185,7 @@ func resourceFronteggWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 	clientHolder := meta.(*restclient.ClientHolder)
 	in := resourceFronteggWebhookSerialize(d)
 	var out fronteggWebhook
-	if err := clientHolder.PortalClient.Patch(ctx, fmt.Sprintf("%s/%s", fronteggWebhookPath, d.Id()), in, &out); err != nil {
+	if err := clientHolder.ApiClient.PatchWithHeaders(ctx, fmt.Sprintf("%s/%s", fronteggWebhookPath, d.Id()), fronteggWebhookHeaders(clientHolder), in, &out); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := resourceFronteggWebhookDeserialize(d, out); err != nil {
@@ -187,14 +197,8 @@ func resourceFronteggWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 func resourceFronteggWebhookDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientHolder := meta.(*restclient.ClientHolder)
 
-	// Configure the client to ignore 404 errors
-	clientHolder.PortalClient.Ignore404()
-
-	// Attempt to delete the webhook
-	err := clientHolder.PortalClient.Delete(ctx, fmt.Sprintf("%s/%s", fronteggWebhookPath, d.Id()), nil)
-
-	// Handle errors other than 404
-	if err != nil {
+	err := clientHolder.ApiClient.DeleteWithHeaders(ctx, fmt.Sprintf("%s/%s", fronteggWebhookPath, d.Id()), fronteggWebhookHeaders(clientHolder), nil)
+	if err != nil && !restclient.IsNotFound(err) {
 		return diag.FromErr(err)
 	}
 

--- a/provider/resource_frontegg_webhook_test.go
+++ b/provider/resource_frontegg_webhook_test.go
@@ -1,0 +1,140 @@
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestVendorIDFromToken(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"type":"vendor","vendorId":"abc-123"}`))
+	token := "header." + payload + ".signature"
+
+	got, err := vendorIDFromToken(token)
+	if err != nil {
+		t.Fatalf("vendorIDFromToken: %v", err)
+	}
+	if got != "abc-123" {
+		t.Errorf("vendorId = %q, want %q", got, "abc-123")
+	}
+}
+
+func TestVendorIDFromTokenRejectsNonJWT(t *testing.T) {
+	for _, token := range []string{"", "not-a-jwt", "only.two"} {
+		if _, err := vendorIDFromToken(token); err == nil {
+			t.Errorf("vendorIDFromToken(%q) = nil error, want error", token)
+		}
+	}
+}
+
+const testAccWebhookCreate = `
+resource "frontegg_webhook" "test" {
+  enabled     = false
+  name        = "tf-acc webhook"
+  description = "created"
+  url         = "https://example.com/webhook"
+  secret      = "tf-acc-webhook-secret"
+  events      = ["frontegg.user.created"]
+}
+`
+
+const testAccWebhookUpdate = `
+resource "frontegg_webhook" "test" {
+  enabled     = true
+  name        = "tf-acc webhook"
+  description = "updated"
+  url         = "https://example.com/webhook-updated"
+  secret      = "tf-acc-webhook-secret"
+  events      = ["frontegg.user.created", "frontegg.user.deleted"]
+}
+`
+
+func TestAccFronteggWebhook_lifecycle(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckWebhookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebhookCreate,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_webhook.test", "description", "created"),
+					resource.TestCheckResourceAttr("frontegg_webhook.test", "enabled", "false"),
+					resource.TestCheckResourceAttr("frontegg_webhook.test", "type", "CUSTOM"),
+					resource.TestCheckResourceAttrSet("frontegg_webhook.test", "vendor_id"),
+				),
+			},
+			{
+				Config:   testAccWebhookCreate,
+				PlanOnly: true,
+			},
+			{
+				Config: testAccWebhookUpdate,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_webhook.test", "description", "updated"),
+					resource.TestCheckResourceAttr("frontegg_webhook.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("frontegg_webhook.test", "events.#", "2"),
+				),
+			},
+			{
+				ResourceName:      "frontegg_webhook.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckWebhookDestroy(s *terraform.State) error {
+	base := os.Getenv("FRONTEGG_API_BASE_URL")
+	if base == "" {
+		base = "https://api.frontegg.com"
+	}
+	var ids []string
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "frontegg_webhook" {
+			ids = append(ids, rs.Primary.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	token := fronteggVendorTokenNoT(base)
+	vendorID, err := vendorIDFromToken(token)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodGet, base+"/webhook", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("frontegg-tenant-id", vendorID)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var out []struct {
+		ID string `json:"_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return err
+	}
+	for _, w := range out {
+		for _, id := range ids {
+			if w.ID == id {
+				return fmt.Errorf("webhook %s still exists after destroy", id)
+			}
+		}
+	}
+	return nil
+}

--- a/provider/vendor_token.go
+++ b/provider/vendor_token.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// vendorIDFromToken extracts the vendorId claim from a Frontegg vendor JWT.
+// Several vendor-scoped API routes require it in a frontegg-tenant-id header.
+// The token is not verified here; it was just issued by /auth/vendor.
+func vendorIDFromToken(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("vendor token is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("failed to decode vendor token payload: %w", err)
+	}
+	var claims struct {
+		VendorID string `json:"vendorId"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("failed to parse vendor token claims: %w", err)
+	}
+	return claims.VendorID, nil
+}


### PR DESCRIPTION
## Problem

Reported by Healthie: `terraform import frontegg_webhook` fails with a 401 on provider v2.9.0, even though `POST /auth/vendor` returns a valid Vendor JWT.

The cause is broader than import. Every `frontegg_webhook` operation went through `PortalClient` (`frontegg-prod.frontegg.com`), and those webhook routes are user-scoped — they expect a logged-in admin's User JWT, which is what the Admin Portal and the vendor dashboard send. The gateway tries to validate the provider's Vendor JWT as a User JWT and rejects it. Import was just the first thing the customer ran; a fresh `apply` fails identically.

Reproduced against the live API with a real Vendor JWT:

```
GET  https://frontegg-prod.frontegg.com/webhook            -> 401 {"errors":["Failed to verify user JWT"]}
POST https://frontegg-prod.frontegg.com/webhook/custom     -> 401 {"errors":["Failed to verify user JWT"]}
GET  https://api.frontegg.com/webhook                      -> 403 {"errors":["Tenant ID is not specified"]}
GET  https://api.frontegg.com/webhook + frontegg-tenant-id -> 200 []
```

Adding the tenant header to the portal host does not help — still 401. It is the host that is wrong, not just the headers.

## Fix

The same `/webhook` paths on `api.frontegg.com` accept the Vendor JWT when the request carries `frontegg-tenant-id` set to the vendor's own ID. Create, read, update and delete now use `ApiClient` with that header. Full CRUD verified against the live API: create, list, `PATCH` and `DELETE` all return 200. There is no `GET /webhook/{id}`, so read still scans the list, as it did before.

The vendor ID is decoded from the `vendorId` claim of the token returned by `/auth/vendor` and carried on `ClientHolder`, falling back to the configured `client_id`. The token is not signature-verified — it was just issued by our own auth call.

Two secondary bugs in the same resource, fixed here:

- Read did not clear the ID when the webhook was absent from the list, so a webhook deleted outside Terraform never surfaced as drift, and importing an unknown ID produced empty state instead of failing.
- Delete used `Ignore404()`, a shared mutable flag on the client that is not concurrency-safe. Replaced with the `restclient.IsNotFound(err)` helper the repo already added for this.

No schema change, so docs need no regeneration.

`frontegg_portal_user` is the other resource still on `PortalClient`. Out of scope here, but worth a separate look for the same problem.

## Testing

New `TestAccFronteggWebhook_lifecycle` covers create -> empty plan -> update -> `ImportState` with `ImportStateVerify`, plus `CheckDestroy`. Unit tests cover the token decoder.

```
--- PASS: TestAccFronteggWebhook_lifecycle (4.28s)
```

The import step is the one the customer is hitting. `go vet`, `gofmt` and `go mod tidy` are clean.