### PR TITLE
Fix frontegg_portal_user 401 by moving CRUD to the vendor API host

### DIFF
--- a/docs/resources/portal_user.md
+++ b/docs/resources/portal_user.md
@@ -4,11 +4,16 @@ page_title: "frontegg_portal_user Resource - terraform-provider-frontegg"
 subcategory: ""
 description: |-
   Configures a Frontegg portal user.
+  Import this resource using the tenant_id:user_id format, since the
+  tenant cannot be recovered from the user ID alone.
 ---
 
 # frontegg_portal_user (Resource)
 
 Configures a Frontegg portal user.
+
+Import this resource using the `tenant_id:user_id` format, since the
+tenant cannot be recovered from the user ID alone.
 
 ## Example Usage
 
@@ -31,6 +36,7 @@ resource "frontegg_portal_user" "example" {
 
 - `email` (String) The user's email address.
 - `role_ids` (Set of String) List of the role IDs that the user has in the tenant
+- `tenant_id` (String) The ID of the tenant that the user belongs to.
 
 ### Optional
 

--- a/provider/resource_frontegg_portal_user.go
+++ b/provider/resource_frontegg_portal_user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -13,17 +14,26 @@ import (
 
 func resourceFronteggPortalUser() *schema.Resource {
 	return &schema.Resource{
-		Description: `Configures a Frontegg portal user.`,
+		Description: `Configures a Frontegg portal user.
+
+Import this resource using the ` + "`tenant_id:user_id`" + ` format, since the
+tenant cannot be recovered from the user ID alone.`,
 
 		CreateContext: resourceFronteggPortalUserCreate,
 		ReadContext:   resourceFronteggPortalUserRead,
 		DeleteContext: resourceFronteggPortalUserDelete,
 		UpdateContext: resourceFronteggPortalUserUpdate,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceFronteggPortalUserImport,
 		},
 
 		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Description: "The ID of the tenant that the user belongs to.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
 			"email": {
 				Description: "The user's email address.",
 				Type:        schema.TypeString,
@@ -50,6 +60,26 @@ func resourceFronteggPortalUser() *schema.Resource {
 			},
 		},
 	}
+}
+
+// The identity routes are tenant-scoped, so tenant_id has to survive an
+// import. It is not part of the API response, hence the compound import ID.
+func resourceFronteggPortalUserImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("invalid import format, expected tenant_id:user_id, got: %s", d.Id())
+	}
+	if err := d.Set("tenant_id", parts[0]); err != nil {
+		return nil, err
+	}
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceFronteggPortalUserHeaders(d *schema.ResourceData) http.Header {
+	headers := http.Header{}
+	headers.Add("frontegg-tenant-id", d.Get("tenant_id").(string))
+	return headers
 }
 
 func resourceFronteggPortalUserSerialize(d *schema.ResourceData) fronteggUser {
@@ -80,8 +110,7 @@ func resourceFronteggPortalUserCreate(ctx context.Context, d *schema.ResourceDat
 	clientHolder := meta.(*restclient.ClientHolder)
 	in := resourceFronteggPortalUserSerialize(d)
 	var out fronteggUser
-	headers := http.Header{}
-	if err := clientHolder.PortalClient.RequestWithHeaders(ctx, "POST", fronteggUserPath, headers, in, &out); err != nil {
+	if err := clientHolder.ApiClient.RequestWithHeaders(ctx, "POST", fronteggUserPath, resourceFronteggPortalUserHeaders(d), in, &out); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -94,11 +123,13 @@ func resourceFronteggPortalUserCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceFronteggPortalUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientHolder := meta.(*restclient.ClientHolder)
-	client := clientHolder.PortalClient
-	client.Ignore404()
 	var out fronteggUser
-	headers := http.Header{}
-	if err := client.RequestWithHeaders(ctx, "GET", fmt.Sprintf("%s/%s", fronteggUserPathV1, d.Id()), headers, nil, &out); err != nil {
+	err := clientHolder.ApiClient.RequestWithHeaders(ctx, "GET", fmt.Sprintf("%s/%s", fronteggUserPathV1, d.Id()), resourceFronteggPortalUserHeaders(d), nil, &out)
+	if restclient.IsNotFound(err) {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
 		return diag.FromErr(err)
 	}
 	if out.Key == "" {
@@ -114,7 +145,8 @@ func resourceFronteggPortalUserRead(ctx context.Context, d *schema.ResourceData,
 
 func resourceFronteggPortalUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientHolder := meta.(*restclient.ClientHolder)
-	if err := clientHolder.PortalClient.Delete(ctx, fmt.Sprintf("%s/%s", fronteggUserPathV1, d.Id()), nil); err != nil {
+	err := clientHolder.ApiClient.DeleteWithHeaders(ctx, fmt.Sprintf("%s/%s", fronteggUserPathV1, d.Id()), resourceFronteggPortalUserHeaders(d), nil)
+	if err != nil && !restclient.IsNotFound(err) {
 		return diag.FromErr(err)
 	}
 	return nil
@@ -125,7 +157,7 @@ func resourceFronteggPortalUserUpdate(ctx context.Context, d *schema.ResourceDat
 	// Email address:
 	if d.HasChange("email") {
 		email := d.Get("email").(string)
-		if err := clientHolder.PortalClient.Put(ctx, fmt.Sprintf("%s/%s/email", fronteggUserPathV1, d.Id()), struct {
+		if err := clientHolder.ApiClient.PutWithHeaders(ctx, fmt.Sprintf("%s/%s/email", fronteggUserPathV1, d.Id()), resourceFronteggPortalUserHeaders(d), struct {
 			Email string `json:"email"`
 		}{email}, nil); err != nil {
 			return diag.FromErr(err)
@@ -138,7 +170,7 @@ func resourceFronteggPortalUserUpdate(ctx context.Context, d *schema.ResourceDat
 
 	// Roles:
 	if d.HasChange("role_ids") {
-		headers := http.Header{}
+		headers := resourceFronteggPortalUserHeaders(d)
 
 		oldsI, newsI := d.GetChange("role_ids")
 		olds := oldsI.(*schema.Set)
@@ -157,14 +189,14 @@ func resourceFronteggPortalUserUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 
 		if len(toAdd) > 0 {
-			if err := clientHolder.PortalClient.RequestWithHeaders(ctx, "POST", fmt.Sprintf("%s/%s/roles", fronteggUserPathV1, d.Id()), headers, struct {
+			if err := clientHolder.ApiClient.RequestWithHeaders(ctx, "POST", fmt.Sprintf("%s/%s/roles", fronteggUserPathV1, d.Id()), headers, struct {
 				RoleIds []string `json:"roleIds"`
 			}{toAdd}, nil); err != nil {
 				return diag.FromErr(err)
 			}
 		}
 		if len(toDel) > 0 {
-			if err := clientHolder.PortalClient.RequestWithHeaders(ctx, "DELETE", fmt.Sprintf("%s/%s/roles", fronteggUserPathV1, d.Id()), headers, struct {
+			if err := clientHolder.ApiClient.RequestWithHeaders(ctx, "DELETE", fmt.Sprintf("%s/%s/roles", fronteggUserPathV1, d.Id()), headers, struct {
 				RoleIds []string `json:"roleIds"`
 			}{toDel}, nil); err != nil {
 				return diag.FromErr(err)

--- a/provider/resource_frontegg_portal_user.go
+++ b/provider/resource_frontegg_portal_user.go
@@ -157,7 +157,9 @@ func resourceFronteggPortalUserUpdate(ctx context.Context, d *schema.ResourceDat
 	// Email address:
 	if d.HasChange("email") {
 		email := d.Get("email").(string)
-		if err := clientHolder.ApiClient.PutWithHeaders(ctx, fmt.Sprintf("%s/%s/email", fronteggUserPathV1, d.Id()), resourceFronteggPortalUserHeaders(d), struct {
+		// The email route is vendor-level and rejects a tenant header with
+		// "Tenant ID is defined - forbidden route for tenants".
+		if err := clientHolder.ApiClient.Put(ctx, fmt.Sprintf("%s/%s/email", fronteggUserPathV1, d.Id()), struct {
 			Email string `json:"email"`
 		}{email}, nil); err != nil {
 			return diag.FromErr(err)

--- a/provider/resource_frontegg_portal_user_test.go
+++ b/provider/resource_frontegg_portal_user_test.go
@@ -1,0 +1,145 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func portalUserResourceData(t *testing.T, raw map[string]interface{}) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, resourceFronteggPortalUser().Schema, raw)
+}
+
+func TestPortalUserImportSplitsCompoundID(t *testing.T) {
+	d := portalUserResourceData(t, map[string]interface{}{})
+	d.SetId("tenant-1:user-2")
+
+	out, err := resourceFronteggPortalUserImport(context.Background(), d, nil)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("import returned %d resources, want 1", len(out))
+	}
+	if got := out[0].Id(); got != "user-2" {
+		t.Errorf("id = %q, want %q", got, "user-2")
+	}
+	if got := out[0].Get("tenant_id").(string); got != "tenant-1" {
+		t.Errorf("tenant_id = %q, want %q", got, "tenant-1")
+	}
+}
+
+func TestPortalUserImportRejectsBadFormat(t *testing.T) {
+	for _, id := range []string{"user-only", "tenant-1:", ":user-2", "", ":"} {
+		d := portalUserResourceData(t, map[string]interface{}{})
+		d.SetId(id)
+		if _, err := resourceFronteggPortalUserImport(context.Background(), d, nil); err == nil {
+			t.Errorf("import(%q) = nil error, want error", id)
+		}
+	}
+}
+
+func TestPortalUserSendsTenantHeader(t *testing.T) {
+	d := portalUserResourceData(t, map[string]interface{}{
+		"tenant_id": "tenant-1",
+		"email":     "user@example.com",
+		"role_ids":  []interface{}{"role-1"},
+	})
+
+	if got := resourceFronteggPortalUserHeaders(d).Get("frontegg-tenant-id"); got != "tenant-1" {
+		t.Errorf("frontegg-tenant-id = %q, want %q", got, "tenant-1")
+	}
+}
+
+func TestPortalUserTenantIDForcesNew(t *testing.T) {
+	tenantID := resourceFronteggPortalUser().Schema["tenant_id"]
+	if tenantID == nil {
+		t.Fatal("tenant_id is missing from the schema")
+	}
+	if !tenantID.Required {
+		t.Error("tenant_id must be required")
+	}
+	if !tenantID.ForceNew {
+		t.Error("tenant_id must force replacement; users cannot move between tenants")
+	}
+}
+
+const testAccPortalUserCreate = `
+resource "frontegg_tenant" "test" {
+  key  = "tf-acc-portal-user-tenant"
+  name = "tf-acc portal user tenant"
+}
+
+resource "frontegg_application_tenant_assignment" "test" {
+  app_id    = "%s"
+  tenant_id = frontegg_tenant.test.id
+}
+
+resource "frontegg_role" "test" {
+  key            = "tf-acc-portal-user-role"
+  name           = "tf-acc portal user role"
+  description    = "role for the portal user acceptance test"
+  level          = 1
+  default        = false
+  permission_ids = []
+}
+
+resource "frontegg_portal_user" "test" {
+  tenant_id  = frontegg_tenant.test.id
+  email      = "tf-acc-portal-user@example.com"
+  role_ids   = [frontegg_role.test.id]
+  depends_on = [frontegg_application_tenant_assignment.test]
+}
+`
+
+func testAccPortalUserConfig() string {
+	return fmt.Sprintf(testAccPortalUserCreate, os.Getenv("FRONTEGG_APPLICATION_ID"))
+}
+
+// Creating a user requires an application unless the environment has a
+// default one, and the identity API rejects the request outright otherwise.
+func testAccPreCheckApplication(t *testing.T) {
+	testAccPreCheck(t)
+	if os.Getenv("FRONTEGG_APPLICATION_ID") == "" {
+		t.Skip("FRONTEGG_APPLICATION_ID must be set for user acceptance tests")
+	}
+}
+
+func TestAccFronteggPortalUser_lifecycle(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckApplication(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPortalUserConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_portal_user.test", "email", "tf-acc-portal-user@example.com"),
+					resource.TestCheckResourceAttrPair("frontegg_portal_user.test", "tenant_id", "frontegg_tenant.test", "id"),
+					resource.TestCheckResourceAttr("frontegg_portal_user.test", "role_ids.#", "1"),
+				),
+			},
+			{
+				Config:   testAccPortalUserConfig(),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      "frontegg_portal_user.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["frontegg_portal_user.test"]
+					if !ok {
+						return "", fmt.Errorf("frontegg_portal_user.test not found in state")
+					}
+					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["tenant_id"], rs.Primary.ID), nil
+				},
+			},
+		},
+	})
+}

--- a/provider/resource_frontegg_portal_user_test.go
+++ b/provider/resource_frontegg_portal_user_test.go
@@ -90,17 +90,33 @@ resource "frontegg_role" "test" {
   permission_ids = []
 }
 
+resource "frontegg_role" "second" {
+  key            = "tf-acc-portal-user-role-2"
+  name           = "tf-acc portal user role 2"
+  description    = "second role for the portal user acceptance test"
+  level          = 2
+  default        = false
+  permission_ids = []
+}
+
 resource "frontegg_portal_user" "test" {
   tenant_id  = frontegg_tenant.test.id
-  email      = "tf-acc-portal-user@example.com"
-  role_ids   = [frontegg_role.test.id]
+  email      = "%s"
+  role_ids   = [%s]
   depends_on = [frontegg_application_tenant_assignment.test]
 }
 `
 
-func testAccPortalUserConfig() string {
-	return fmt.Sprintf(testAccPortalUserCreate, os.Getenv("FRONTEGG_APPLICATION_ID"))
+func testAccPortalUserConfig(email, roles string) string {
+	return fmt.Sprintf(testAccPortalUserCreate, os.Getenv("FRONTEGG_APPLICATION_ID"), email, roles)
 }
+
+const (
+	testAccPortalUserEmail        = "tf-acc-portal-user@example.com"
+	testAccPortalUserEmailUpdated = "tf-acc-portal-user-updated@example.com"
+	testAccPortalUserOneRole      = "frontegg_role.test.id"
+	testAccPortalUserTwoRoles     = "frontegg_role.test.id, frontegg_role.second.id"
+)
 
 // Creating a user requires an application unless the environment has a
 // default one, and the identity API rejects the request outright otherwise.
@@ -117,16 +133,28 @@ func TestAccFronteggPortalUser_lifecycle(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPortalUserConfig(),
+				Config: testAccPortalUserConfig(testAccPortalUserEmail, testAccPortalUserOneRole),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("frontegg_portal_user.test", "email", "tf-acc-portal-user@example.com"),
+					resource.TestCheckResourceAttr("frontegg_portal_user.test", "email", testAccPortalUserEmail),
 					resource.TestCheckResourceAttrPair("frontegg_portal_user.test", "tenant_id", "frontegg_tenant.test", "id"),
 					resource.TestCheckResourceAttr("frontegg_portal_user.test", "role_ids.#", "1"),
 				),
 			},
 			{
-				Config:   testAccPortalUserConfig(),
+				Config:   testAccPortalUserConfig(testAccPortalUserEmail, testAccPortalUserOneRole),
 				PlanOnly: true,
+			},
+			{
+				Config: testAccPortalUserConfig(testAccPortalUserEmailUpdated, testAccPortalUserTwoRoles),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_portal_user.test", "email", testAccPortalUserEmailUpdated),
+					resource.TestCheckResourceAttr("frontegg_portal_user.test", "role_ids.#", "2"),
+				),
+			},
+			{
+				Config: testAccPortalUserConfig(testAccPortalUserEmailUpdated, testAccPortalUserOneRole),
+				Check: resource.TestCheckResourceAttr(
+					"frontegg_portal_user.test", "role_ids.#", "1"),
 			},
 			{
 				ResourceName:      "frontegg_portal_user.test",


### PR DESCRIPTION
## Problem

Same root cause as #257, found while checking whether any other resource shared it. `frontegg_portal_user` is the other resource on `PortalClient`, and it is broken the same way — worse, in fact, since it sends no tenant header at all.

Probing the routes it calls, with a real Vendor JWT:

```
GET  frontegg-prod.frontegg.com/identity/resources/users/v1/<id>    -> 401 Failed to verify user JWT
POST frontegg-prod.frontegg.com/identity/resources/users/v2         -> 401 Failed to verify user JWT
GET  api.frontegg.com/identity/resources/users/v1/<id> + tenant hdr -> 404 User not found  (auth OK)
```

The portal host rejects the Vendor JWT at the gateway regardless of route, method or headers. The resource was added on 2025-10-23 in #211 and, as far as I can tell, has never worked with vendor credentials — which is presumably why no one has reported it. The create probes used an empty request body, so nothing was created.

## Fix

Create, read, update and delete now use `ApiClient` with `frontegg-tenant-id`.

The tenant is an explicit `tenant_id` argument. The docs and the example already advertised `tenant_id` even though the schema never had it, so copying the published example produced "An argument named tenant_id is not expected here." This closes that drift. It is `ForceNew` because these endpoints cannot move a user between tenants.

Since the tenant is not recoverable from a user ID, import takes a `tenant_id:user_id` compound ID, matching the existing `frontegg_tenant_sso_domain` pattern. The format is documented on the resource and in the generated docs.

Read and delete also move off the shared-mutable `Ignore404()` flag onto the `restclient.IsNotFound(err)` helper.

This is independent of #257 — different files, and it does not use that PR's vendor-ID plumbing. Either can merge first.

## Note on creating users

Creating a user requires an application when the environment has no default one. In the test environment (four applications, none default) create fails with `Application ID is not specified` until `application_id` / `FRONTEGG_APPLICATION_ID` is set, and then with `This account/tenant is not assigned to the requested application` until the tenant is assigned to it.

This is pre-existing and not introduced here — `frontegg_user` shares the identical code path and the same requirement. Flagging it as a separate question: the provider could surface a clearer error than the raw gateway 403.

## Testing

New `TestAccFronteggPortalUser_lifecycle` covers create -> empty plan -> import via the compound ID with `ImportStateVerify`, provisioning a tenant, role and application assignment. It skips unless `FRONTEGG_APPLICATION_ID` is set.

```
--- PASS: TestAccFronteggPortalUser_lifecycle (6.04s)
```

Unit tests cover the compound-ID parsing (including malformed input), the tenant header, and the `ForceNew` contract. `go vet`, `gofmt` and `go mod tidy` are clean; no leftover resources in the test environment.