### PR TITLE
Explain the application requirement when user creation fails

### DIFF
--- a/provider/resource_frontegg_portal_user.go
+++ b/provider/resource_frontegg_portal_user.go
@@ -111,7 +111,7 @@ func resourceFronteggPortalUserCreate(ctx context.Context, d *schema.ResourceDat
 	in := resourceFronteggPortalUserSerialize(d)
 	var out fronteggUser
 	if err := clientHolder.ApiClient.RequestWithHeaders(ctx, "POST", fronteggUserPath, resourceFronteggPortalUserHeaders(d), in, &out); err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fronteggUserApplicationError(err))
 	}
 
 	if err := resourceFronteggPortalUserDeserialize(d, out); err != nil {

--- a/provider/resource_frontegg_user.go
+++ b/provider/resource_frontegg_user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -33,6 +34,40 @@ type fronteggUser struct {
 
 const fronteggUserPath = "/identity/resources/users/v2"
 const fronteggUserPathV1 = "/identity/resources/users/v1"
+
+// Frontegg error codes returned when user creation cannot resolve an
+// application. The gateway reports both as bare HTTP failures that say
+// nothing about which provider setting is missing.
+const (
+	fronteggErrNoApplicationID    = "ER-00008"
+	fronteggErrTenantNotInAppCode = "ER-01008"
+)
+
+// fronteggUserApplicationError turns the two opaque application failures from
+// the identity API into guidance naming the setting and resource that fix
+// them. Any other error is returned unchanged.
+func fronteggUserApplicationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case strings.Contains(err.Error(), fronteggErrNoApplicationID):
+		return fmt.Errorf(
+			"creating a Frontegg user requires an application, and this environment has no default one. "+
+				"Set `application_id` on the provider (or the FRONTEGG_APPLICATION_ID environment variable) "+
+				"to the application the user should belong to.\n\noriginal error: %w",
+			err,
+		)
+	case strings.Contains(err.Error(), fronteggErrTenantNotInAppCode):
+		return fmt.Errorf(
+			"the tenant is not assigned to the application named by `application_id`. "+
+				"Assign it with a `frontegg_application_tenant_assignment` resource, and make the user "+
+				"depend on that assignment so it is created first.\n\noriginal error: %w",
+			err,
+		)
+	}
+	return err
+}
 
 func resourceFronteggUser() *schema.Resource {
 	return &schema.Resource{
@@ -124,7 +159,7 @@ func resourceFronteggUserCreate(ctx context.Context, d *schema.ResourceData, met
 	headers := http.Header{}
 	headers.Add("frontegg-tenant-id", d.Get("tenant_id").(string))
 	if err := clientHolder.ApiClient.RequestWithHeaders(ctx, "POST", fronteggUserPath, headers, in, &out); err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fronteggUserApplicationError(err))
 	}
 
 	if err := resourceFronteggUserDeserialize(d, out); err != nil {

--- a/provider/resource_frontegg_user_test.go
+++ b/provider/resource_frontegg_user_test.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Verbatim errors observed from the identity API when creating a user in an
+// environment whose applications include no default.
+var (
+	errNoApplication = errors.New(
+		`restclient: request failed: POST https://api.frontegg.com/identity/resources/users/v2: ` +
+			`403 Forbidden: map[]: {"errors":["Application ID is not specified"],"errorCode":"ER-00008"}`,
+	)
+	errTenantNotAssigned = errors.New(
+		`restclient: request failed: POST https://api.frontegg.com/identity/resources/users/v2: ` +
+			`404 Not Found: map[]: {"errors":["This account/tenant is not assigned to the requested application"],"errorCode":"ER-01008"}`,
+	)
+)
+
+func TestUserApplicationErrorNamesProviderSetting(t *testing.T) {
+	got := fronteggUserApplicationError(errNoApplication)
+	if got == nil {
+		t.Fatal("got nil error, want a translated error")
+	}
+	for _, want := range []string{"application_id", "FRONTEGG_APPLICATION_ID"} {
+		if !strings.Contains(got.Error(), want) {
+			t.Errorf("error does not mention %q: %s", want, got)
+		}
+	}
+	if !errors.Is(got, errNoApplication) {
+		t.Error("translated error must wrap the original")
+	}
+}
+
+func TestUserApplicationErrorNamesAssignmentResource(t *testing.T) {
+	got := fronteggUserApplicationError(errTenantNotAssigned)
+	if got == nil {
+		t.Fatal("got nil error, want a translated error")
+	}
+	if !strings.Contains(got.Error(), "frontegg_application_tenant_assignment") {
+		t.Errorf("error does not name the assignment resource: %s", got)
+	}
+	if !errors.Is(got, errTenantNotAssigned) {
+		t.Error("translated error must wrap the original")
+	}
+}
+
+func TestUserApplicationErrorPassesOthersThrough(t *testing.T) {
+	other := errors.New(`restclient: request failed: 400 Bad Request: {"errors":["email must be an email"]}`)
+	if got := fronteggUserApplicationError(other); got != other {
+		t.Errorf("unrelated error was rewritten: %s", got)
+	}
+	if got := fronteggUserApplicationError(nil); got != nil {
+		t.Errorf("nil error became %v", got)
+	}
+}


### PR DESCRIPTION
Follow-up to the question raised in #258.

**Stacked on #258** — base branch is `fix-portal-user-vendor-api-host`, not `master`, because it touches the same create path. Merge #258 first and this retargets to `master` on its own.

## Problem

Creating a user through the identity API needs an application when the environment has no default one. The gateway reports that as a bare 403, and once an application is named but the tenant is not assigned to it, as a bare 404:

```
403 {"errors":["Application ID is not specified"],"errorCode":"ER-00008"}
404 {"errors":["This account/tenant is not assigned to the requested application"],"errorCode":"ER-01008"}
```

Neither names the provider setting or the resource that fixes it, so the user is left to work it out from a raw gateway response. This affects `frontegg_user` and `frontegg_portal_user`, which share the create path, and predates both #257 and #258.

## Fix

Translate the two error codes into actionable guidance, wrapping the original with `%w` so nothing is lost and `errors.Is` still works. Any other error passes through untouched.

What the user now sees:

```
Error: creating a Frontegg user requires an application, and this environment has no
default one. Set `application_id` on the provider (or the FRONTEGG_APPLICATION_ID
environment variable) to the application the user should belong to.

original error: restclient: request failed: POST .../identity/resources/users/v2: 403 ...
```

and for the second case:

```
Error: the tenant is not assigned to the application named by `application_id`. Assign
it with a `frontegg_application_tenant_assignment` resource, and make the user depend on
that assignment so it is created first.
```

## Testing

Both paths were driven end to end against the live API through the provider, in a throwaway test that I did not keep: one apply with no application configured, one with an application but an unassigned tenant. Each produced the intended message. The committed unit tests assert on the verbatim error payloads captured from those runs, and cover pass-through of unrelated errors and of `nil`.

I deliberately did not commit those two as acceptance tests. Both depend on the environment having no default application and no auto-assignment of new tenants, which would make them flaky in CI for a reason unrelated to what they check.

## Not addressed

The wrapped original error is very noisy — `restclient` formats the entire response header map into the message, so the useful JSON body sits behind a wall of CloudFront and CSP headers. The actionable text now comes first, which is the main thing, but trimming that format would improve every error the provider emits. Left out here since it touches all resources rather than this one path.