### PR TITLE
Trim the response header dump out of restclient errors

### DIFF
--- a/internal/restclient/restclient.go
+++ b/internal/restclient/restclient.go
@@ -52,6 +52,16 @@ func IsNotFound(err error) bool {
 	return err != nil && strings.Contains(err.Error(), ": 404 ")
 }
 
+// traceSuffix returns the Frontegg trace ID as a short parenthetical, for
+// quoting when escalating a failure. The full response headers are dumped at
+// TRACE level instead of into the error, where they buried the response body.
+func traceSuffix(h http.Header) string {
+	if id := h.Get("Frontegg-Trace-Id"); id != "" {
+		return fmt.Sprintf(" (trace %s)", id)
+	}
+	return ""
+}
+
 func (c *Client) DeleteWithHeaders(ctx context.Context, url string, headers http.Header, out interface{}) error {
 	return c.RequestWithHeaders(ctx, "DELETE", url, headers, nil, out)
 }
@@ -203,9 +213,10 @@ func (c *Client) RequestWithHeaders(ctx context.Context, method string, url stri
 			// because this single wait would cross it. A lone reset window (even
 			// a long one) is always honored; the ceiling bounds repeated cycles.
 			if c.rl.exceeded(attempts, totalWait) {
+				log.Printf("[TRACE] Response headers for failed request: %v", res.Header)
 				return fmt.Errorf(
-					"restclient: rate limited and gave up after %d attempts (%s total): %s %s: %s: %v: %s",
-					attempts, totalWait, req.Method, req.URL, res.Status, res.Header, resBody,
+					"restclient: rate limited and gave up after %d attempts (%s total): %s %s: %s%s: %s",
+					attempts, totalWait, req.Method, req.URL, res.Status, traceSuffix(res.Header), resBody,
 				)
 			}
 			log.Printf(
@@ -218,9 +229,10 @@ func (c *Client) RequestWithHeaders(ctx context.Context, method string, url stri
 			totalWait += wait
 			continue
 		case res.StatusCode < 200 || res.StatusCode >= 300:
+			log.Printf("[TRACE] Response headers for failed request: %v", res.Header)
 			return fmt.Errorf(
-				"restclient: request failed: %s %s: %s: %v: %s",
-				req.Method, req.URL, res.Status, res.Header, resBody,
+				"restclient: request failed: %s %s: %s%s: %s",
+				req.Method, req.URL, res.Status, traceSuffix(res.Header), resBody,
 			)
 		}
 

--- a/internal/restclient/restclient_test.go
+++ b/internal/restclient/restclient_test.go
@@ -632,3 +632,78 @@ func TestStoryExampleResetParses(t *testing.T) {
 	}
 	_ = fmt.Sprintf("%v", d)
 }
+
+// TestErrorOmitsResponseHeaders verifies the failure message carries the
+// status and body without the response header dump that used to bury them.
+func TestErrorOmitsResponseHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Amz-Cf-Pop", "LHR82-P3")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors":["nope"],"errorCode":"ER-00008"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.Get(context.Background(), "/thing", nil)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	for _, want := range []string{"403 Forbidden", "ER-00008"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error is missing %q: %s", want, err)
+		}
+	}
+	for _, unwanted := range []string{"X-Amz-Cf-Pop", "Content-Security-Policy", "LHR82-P3"} {
+		if strings.Contains(err.Error(), unwanted) {
+			t.Errorf("error still dumps response headers (%q): %s", unwanted, err)
+		}
+	}
+}
+
+// TestErrorIncludesTraceID verifies the Frontegg trace ID survives the trim,
+// since that is the one header worth quoting when escalating a failure.
+func TestErrorIncludesTraceID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Frontegg-Trace-Id", "abc123")
+		w.Header().Set("X-Amz-Cf-Pop", "LHR82-P3")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.Get(context.Background(), "/thing", nil)
+	if err == nil || !strings.Contains(err.Error(), "(trace abc123)") {
+		t.Fatalf("expected the trace ID in the error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "X-Amz-Cf-Pop") {
+		t.Errorf("only the trace ID should survive: %s", err)
+	}
+}
+
+// TestIsNotFoundSurvivesTrimmedFormat guards the substring IsNotFound matches
+// on, which the error format change could silently break.
+func TestIsNotFoundSurvivesTrimmedFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Frontegg-Trace-Id", "abc123")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":["User not found"]}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.Get(context.Background(), "/thing", nil)
+	if !IsNotFound(err) {
+		t.Fatalf("IsNotFound must still recognize a 404: %v", err)
+	}
+
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv2.Close()
+	c2 := newTestClient(srv2.URL)
+	if IsNotFound(c2.Get(context.Background(), "/thing", nil)) {
+		t.Error("IsNotFound must not match a 500")
+	}
+}

--- a/provider/resource_frontegg_user_test.go
+++ b/provider/resource_frontegg_user_test.go
@@ -11,11 +11,13 @@ import (
 var (
 	errNoApplication = errors.New(
 		`restclient: request failed: POST https://api.frontegg.com/identity/resources/users/v2: ` +
-			`403 Forbidden: map[]: {"errors":["Application ID is not specified"],"errorCode":"ER-00008"}`,
+			`403 Forbidden (trace 468ccbfcb42b35d6f7462a49e4be21af): ` +
+			`{"errors":["Application ID is not specified"],"errorCode":"ER-00008"}`,
 	)
 	errTenantNotAssigned = errors.New(
 		`restclient: request failed: POST https://api.frontegg.com/identity/resources/users/v2: ` +
-			`404 Not Found: map[]: {"errors":["This account/tenant is not assigned to the requested application"],"errorCode":"ER-01008"}`,
+			`404 Not Found (trace 0e1631177c43f600ed747b6392560cf6): ` +
+			`{"errors":["This account/tenant is not assigned to the requested application"],"errorCode":"ER-01008"}`,
 	)
 )
 


### PR DESCRIPTION
Follow-up to the "Not addressed" note in #259.

**Stacked on #259** (which is itself stacked on #258) — base is `improve-user-application-errors`. It touches `internal/restclient` plus the error fixtures added in #259. Merge the stack in order and this retargets on its own.

## Problem

Every non-2xx error formatted the entire `http.Header` map into its message:

```
restclient: request failed: POST .../users/v2: 403 Forbidden: map[Alt-Svc:[h3=":443"; ma=86400]
Content-Length:[69] Content-Security-Policy:[default-src 'self';base-uri 'self';font-src 'self'
https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';
script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-
requests] Content-Type:[application/json; charset=utf-8] Cross-Origin-Opener-Policy:[same-origin]
... twenty more headers ...]: {"errors":["Application ID is not specified"],"errorCode":"ER-00008"}
```

Terraform prints these verbatim, so the status and the response body — the only parts that say what went wrong — were the hardest parts to find. This affects every resource in the provider.

## Fix

Drop the header map from the generic failure and the rate-limit give-up message. Keep the Frontegg trace ID as a short parenthetical, since that is the one header worth quoting when escalating to support. Same failure now reads:

```
restclient: request failed: POST .../users/v2: 403 Forbidden (trace 7c7128eec332b02127fc834376a8bab0):
{"errors":["Application ID is not specified"],"errorCode":"ER-00008"}
```

Nothing is lost for debugging: the full headers are logged at TRACE, alongside the existing request and body logging, so `TF_LOG=TRACE` still shows everything.

## The contract this could have broken

`restclient.IsNotFound` matches on the `": 404 "` substring of this exact message, and every Read function that distinguishes a deleted resource from a real failure depends on it. The status stays in the same position and keeps its leading `": "`, so the match holds — and there is now a test pinning it, driving a real 404 through the client rather than asserting on a hand-written string.

## Testing

Three new tests in `internal/restclient`: the header dump is gone, the trace ID survives, and `IsNotFound` still recognizes a 404 while not matching a 500. The `frontegg_user` fixtures from #259 are updated to the new format, since they are meant to be verbatim samples of what this path produces.

Verified end to end against the live API — the output above is the real rendered error from a `terraform apply`, not a reconstruction. Full unit suite and lint pass.