### PR TITLE
Add acceptance coverage for frontegg_user, and fix what it found

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -4,11 +4,16 @@ page_title: "frontegg_user Resource - terraform-provider-frontegg"
 subcategory: ""
 description: |-
   Configures a Frontegg user.
+  Import this resource using the tenant_id:user_id format, since the
+  tenant cannot be recovered from the user ID alone.
 ---
 
 # frontegg_user (Resource)
 
 Configures a Frontegg user.
+
+Import this resource using the `tenant_id:user_id` format, since the
+tenant cannot be recovered from the user ID alone.
 
 
 

--- a/provider/resource_frontegg_user.go
+++ b/provider/resource_frontegg_user.go
@@ -71,14 +71,17 @@ func fronteggUserApplicationError(err error) error {
 
 func resourceFronteggUser() *schema.Resource {
 	return &schema.Resource{
-		Description: `Configures a Frontegg user.`,
+		Description: `Configures a Frontegg user.
+
+Import this resource using the ` + "`tenant_id:user_id`" + ` format, since the
+tenant cannot be recovered from the user ID alone.`,
 
 		CreateContext: resourceFronteggUserCreate,
 		ReadContext:   resourceFronteggUserRead,
 		DeleteContext: resourceFronteggUserDelete,
 		UpdateContext: resourceFronteggUserUpdate,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceFronteggUserImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -116,6 +119,7 @@ func resourceFronteggUser() *schema.Resource {
 				Description: "The tenant ID for this user.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"superuser": {
 				Description: "Whether the user is a super user.",
@@ -124,6 +128,20 @@ func resourceFronteggUser() *schema.Resource {
 			},
 		},
 	}
+}
+
+// The identity routes are tenant-scoped, so tenant_id has to survive an
+// import. It is not part of the API response, hence the compound import ID.
+func resourceFronteggUserImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("invalid import format, expected tenant_id:user_id, got: %s", d.Id())
+	}
+	if err := d.Set("tenant_id", parts[0]); err != nil {
+		return nil, err
+	}
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceFronteggUserSerialize(d *schema.ResourceData) fronteggUser {

--- a/provider/resource_frontegg_user_test.go
+++ b/provider/resource_frontegg_user_test.go
@@ -1,9 +1,16 @@
 package provider
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // Verbatim errors observed from the identity API when creating a user in an
@@ -56,5 +63,144 @@ func TestUserApplicationErrorPassesOthersThrough(t *testing.T) {
 	}
 	if got := fronteggUserApplicationError(nil); got != nil {
 		t.Errorf("nil error became %v", got)
+	}
+}
+
+const testAccUserBase = `
+resource "frontegg_tenant" "u" {
+  key  = "tf-acc-user-tenant"
+  name = "tf-acc user tenant"
+}
+
+resource "frontegg_application_tenant_assignment" "u" {
+  app_id    = "%s"
+  tenant_id = frontegg_tenant.u.id
+}
+
+resource "frontegg_role" "u1" {
+  key            = "tf-acc-user-role-1"
+  name           = "tf-acc user role 1"
+  description    = "first role for the user acceptance test"
+  level          = 1
+  default        = false
+  permission_ids = []
+}
+
+resource "frontegg_role" "u2" {
+  key            = "tf-acc-user-role-2"
+  name           = "tf-acc user role 2"
+  description    = "second role for the user acceptance test"
+  level          = 2
+  default        = false
+  permission_ids = []
+}
+
+resource "frontegg_user" "u" {
+  tenant_id         = frontegg_tenant.u.id
+  email             = "%s"
+  role_ids          = [%s]
+  superuser         = %t
+  skip_invite_email = true
+  depends_on        = [frontegg_application_tenant_assignment.u]
+}
+`
+
+func testAccUserConfig(email, roles string, superuser bool) string {
+	return fmt.Sprintf(testAccUserBase, os.Getenv("FRONTEGG_APPLICATION_ID"), email, roles, superuser)
+}
+
+const (
+	testAccUserEmail        = "tf-acc-user@example.com"
+	testAccUserEmailUpdated = "tf-acc-user-updated@example.com"
+	testAccUserOneRole      = "frontegg_role.u1.id"
+	testAccUserTwoRoles     = "frontegg_role.u1.id, frontegg_role.u2.id"
+)
+
+func TestAccFronteggUser_lifecycle(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckApplication(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig(testAccUserEmail, testAccUserOneRole, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_user.u", "email", testAccUserEmail),
+					resource.TestCheckResourceAttrPair("frontegg_user.u", "tenant_id", "frontegg_tenant.u", "id"),
+					resource.TestCheckResourceAttr("frontegg_user.u", "role_ids.#", "1"),
+				),
+			},
+			{
+				Config:   testAccUserConfig(testAccUserEmail, testAccUserOneRole, false),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccUserConfig(testAccUserEmailUpdated, testAccUserTwoRoles, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_user.u", "email", testAccUserEmailUpdated),
+					resource.TestCheckResourceAttr("frontegg_user.u", "role_ids.#", "2"),
+				),
+			},
+			{
+				Config: testAccUserConfig(testAccUserEmailUpdated, testAccUserOneRole, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_user.u", "role_ids.#", "1"),
+					resource.TestCheckResourceAttr("frontegg_user.u", "superuser", "true"),
+				),
+			},
+			{
+				ResourceName:      "frontegg_user.u",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// Neither is part of the user payload; they only describe
+					// how the resource was created.
+					"skip_invite_email",
+					"superuser",
+				},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["frontegg_user.u"]
+					if !ok {
+						return "", fmt.Errorf("frontegg_user.u not found in state")
+					}
+					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["tenant_id"], rs.Primary.ID), nil
+				},
+			},
+		},
+	})
+}
+
+func TestUserImportSplitsCompoundID(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceFronteggUser().Schema, map[string]interface{}{})
+	d.SetId("tenant-1:user-2")
+
+	out, err := resourceFronteggUserImport(context.Background(), d, nil)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if got := out[0].Id(); got != "user-2" {
+		t.Errorf("id = %q, want %q", got, "user-2")
+	}
+	if got := out[0].Get("tenant_id").(string); got != "tenant-1" {
+		t.Errorf("tenant_id = %q, want %q", got, "tenant-1")
+	}
+}
+
+func TestUserImportRejectsBadFormat(t *testing.T) {
+	for _, id := range []string{"user-only", "tenant-1:", ":user-2", "", ":"} {
+		d := schema.TestResourceDataRaw(t, resourceFronteggUser().Schema, map[string]interface{}{})
+		d.SetId(id)
+		if _, err := resourceFronteggUserImport(context.Background(), d, nil); err == nil {
+			t.Errorf("import(%q) = nil error, want error", id)
+		}
+	}
+}
+
+// Moving a user between tenants is not something these endpoints support, so
+// the change has to replace the resource rather than silently orphan the user
+// in the old tenant.
+func TestUserTenantIDForcesNew(t *testing.T) {
+	tenantID := resourceFronteggUser().Schema["tenant_id"]
+	if !tenantID.ForceNew {
+		t.Error("tenant_id must force replacement")
 	}
 }


### PR DESCRIPTION
Follow-up to the coverage gap noted on #260.

**Stacked on #260** (→ #259 → #258). Base is `trim-restclient-error-noise`; it retargets as the stack lands.

## Why

`frontegg_user` had no acceptance test at all. It also shares the code path I had been editing for `frontegg_portal_user`, and that resource turned out to have two bugs that only surfaced once its update and import paths were actually driven against the API. Same exercise here found the same two.

## Bug 1 — import never worked

The resource advertises passthrough import, but read builds a `frontegg-tenant-id` header from `tenant_id`, which is not in state during an import. Every import failed:

```
GET .../identity/resources/users/v1/70c799be-...: 403 {"errors":["Tenant ID is not specified"]}
```

Import now takes a `tenant_id:user_id` compound ID, matching `frontegg_portal_user` and `frontegg_tenant_sso_domain`. This is technically a breaking change to the import format, but nobody can be relying on the old one — it returns 403 unconditionally.

## Bug 2 — changing tenant_id silently orphaned the user

`tenant_id` was `Required` but not `ForceNew`, and update does not handle it. So the user stayed in the old tenant while state moved to the new one, the next read 404'd against the new tenant, and Terraform planned a fresh create — leaving the original user behind. Observed directly:

```
# frontegg_user.u will be created
+ resource "frontegg_user" "u" { ... }
Plan: 1 to add, 0 to change, 0 to destroy.
```

`ForceNew` makes the change an explicit destroy-and-create, which is what these endpoints actually support.

## Testing

`TestAccFronteggUser_lifecycle` covers create → empty plan → email change → role added → role removed → superuser toggle → import → destroy, against a real environment:

```
--- PASS: TestAccFronteggUser_lifecycle (6.34s)
```

Both bugs above were reproduced live before fixing and confirmed fixed after. Unit tests cover the compound-ID parsing, malformed IDs, and the `ForceNew` contract. `skip_invite_email` and `superuser` are in `ImportStateVerifyIgnore` — neither is part of the user payload, they only describe how the resource was created. The test sets `skip_invite_email = true` so no invite mail is attempted.

## Not covered

The password change path (`POST /users/v1/passwords/change`) is untested. It takes the old and new password and is aimed at an end user changing their own credentials, so exercising it from a vendor token needs its own investigation rather than a test written on assumption. Worth a separate look.