### PR TITLE
Fix drift and import for allowed_origin, social_login and email_template

### DIFF
--- a/provider/resource_frontegg_allowed_origin.go
+++ b/provider/resource_frontegg_allowed_origin.go
@@ -69,7 +69,11 @@ func resourceFronteggAllowedOriginRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
+	// On import only the ID is set, and the ID is the origin itself.
 	origin := d.Get("allowed_origin").(string)
+	if origin == "" {
+		origin = d.Id()
+	}
 	if !containsAllowedOrigin(allowedOrigins, origin) {
 		d.SetId("")
 		return nil

--- a/provider/resource_frontegg_allowed_origin.go
+++ b/provider/resource_frontegg_allowed_origin.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -95,7 +96,7 @@ func resourceFronteggAllowedOriginDelete(ctx context.Context, d *schema.Resource
 
 	newOrigins := make([]string, 0, len(allowedOrigins.AllowedOrigins)-1)
 	for _, origin := range allowedOrigins.AllowedOrigins {
-		if origin != originToDelete {
+		if normalizeAllowedOrigin(origin) != normalizeAllowedOrigin(originToDelete) {
 			newOrigins = append(newOrigins, origin)
 		}
 	}
@@ -127,9 +128,17 @@ func updateAllowedOrigins(ctx context.Context, meta interface{}, origins *fronte
 	return nil
 }
 
+// The API stores origins with a trailing slash regardless of how they were
+// submitted, so comparisons have to ignore it. Without this every read reports
+// the origin as missing, which shows up as permanent drift and makes delete
+// fail with "origin does not exist".
+func normalizeAllowedOrigin(origin string) string {
+	return strings.TrimSuffix(origin, "/")
+}
+
 func containsAllowedOrigin(origins *fronteggAllowedOrigins, newOrigin string) bool {
 	for _, origin := range origins.AllowedOrigins {
-		if origin == newOrigin {
+		if normalizeAllowedOrigin(origin) == normalizeAllowedOrigin(newOrigin) {
 			return true
 		}
 	}

--- a/provider/resource_frontegg_allowed_origin_test.go
+++ b/provider/resource_frontegg_allowed_origin_test.go
@@ -1,0 +1,32 @@
+package provider
+
+import "testing"
+
+// The API stores every origin with a trailing slash, so a configuration that
+// omits it must still match what comes back.
+func TestContainsAllowedOriginIgnoresTrailingSlash(t *testing.T) {
+	stored := &fronteggAllowedOrigins{AllowedOrigins: []string{
+		"http://localhost:3000/",
+		"https://app.example.com/",
+	}}
+
+	for _, origin := range []string{
+		"https://app.example.com",
+		"https://app.example.com/",
+		"http://localhost:3000",
+	} {
+		if !containsAllowedOrigin(stored, origin) {
+			t.Errorf("containsAllowedOrigin(%q) = false, want true", origin)
+		}
+	}
+
+	for _, origin := range []string{
+		"https://other.example.com",
+		"https://app.example.com/path",
+		"",
+	} {
+		if containsAllowedOrigin(stored, origin) {
+			t.Errorf("containsAllowedOrigin(%q) = true, want false", origin)
+		}
+	}
+}

--- a/provider/resource_frontegg_allowed_origin_test.go
+++ b/provider/resource_frontegg_allowed_origin_test.go
@@ -1,6 +1,10 @@
 package provider
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
 
 // The API stores every origin with a trailing slash, so a configuration that
 // omits it must still match what comes back.
@@ -29,4 +33,34 @@ func TestContainsAllowedOriginIgnoresTrailingSlash(t *testing.T) {
 			t.Errorf("containsAllowedOrigin(%q) = true, want false", origin)
 		}
 	}
+}
+
+const testAccAllowedOrigin = `
+resource "frontegg_allowed_origin" "test" {
+  allowed_origin = "https://tf-acc-origin.example.com"
+}
+`
+
+func TestAccFronteggAllowedOrigin_lifecycle(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAllowedOrigin,
+				Check: resource.TestCheckResourceAttr(
+					"frontegg_allowed_origin.test", "allowed_origin", "https://tf-acc-origin.example.com"),
+			},
+			{
+				Config:   testAccAllowedOrigin,
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      "frontegg_allowed_origin.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "https://tf-acc-origin.example.com",
+			},
+		},
+	})
 }

--- a/provider/resource_frontegg_email_template.go
+++ b/provider/resource_frontegg_email_template.go
@@ -164,7 +164,11 @@ func resourceFronteggEmailTemplateRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
+	// On import only the ID is set, and the ID is the template type.
 	templateType := d.Get("template_type").(string)
+	if templateType == "" {
+		templateType = d.Id()
+	}
 	for _, template := range out {
 		if template.Type == templateType {
 			if err := resourceFronteggEmailTemplateDeserialize(d, template); err != nil {

--- a/provider/resource_frontegg_email_template_test.go
+++ b/provider/resource_frontegg_email_template_test.go
@@ -1,9 +1,12 @@
 package provider
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // TestEmailTemplateDeserializePrefersPatternFields verifies that reading a
@@ -54,5 +57,35 @@ func TestEmailTemplateDeserializePrefersPatternFields(t *testing.T) {
 				t.Errorf("success_redirect_url = %q, want %q", got, tt.wantSuccessRedirectURL)
 			}
 		})
+	}
+}
+
+// Email templates cannot be deleted — delete only drops them from state — so a
+// normal acceptance test would permanently alter a shared template. This drives
+// the read path with only the ID set, exactly as an import does, and mutates
+// nothing.
+func TestAccEmailTemplateImportRead(t *testing.T) {
+	testAccPreCheck(t)
+
+	p := New("test")()
+	cfg := terraform.NewResourceConfigRaw(map[string]interface{}{
+		"client_id":  os.Getenv("FRONTEGG_CLIENT_ID"),
+		"secret_key": os.Getenv("FRONTEGG_SECRET_KEY"),
+	})
+	if diags := p.Configure(context.Background(), cfg); diags.HasError() {
+		t.Fatalf("configure provider: %v", diags)
+	}
+
+	d := schema.TestResourceDataRaw(t, resourceFronteggEmailTemplate().Schema, map[string]interface{}{})
+	d.SetId("ResetPassword")
+
+	if diags := resourceFronteggEmailTemplateRead(context.Background(), d, p.Meta()); diags.HasError() {
+		t.Fatalf("read: %v", diags)
+	}
+	if d.Id() == "" {
+		t.Fatal("read cleared the ID, so import would fail")
+	}
+	if got := d.Get("template_type").(string); got != "ResetPassword" {
+		t.Errorf("template_type = %q, want ResetPassword", got)
 	}
 }

--- a/provider/resource_frontegg_social_login.go
+++ b/provider/resource_frontegg_social_login.go
@@ -114,7 +114,54 @@ func resourceFronteggSocialLoginDeserialize(d *schema.ResourceData, f fronteggSS
 	return nil
 }
 
+// socialLoginAdoptionReason reports why creating over an existing provider
+// configuration would destroy information Terraform did not supply, or "" when
+// it is safe to proceed.
+//
+// Creating a provider is a POST that overwrites whatever is already there, so
+// pointing this resource at a provider somebody configured by hand silently
+// takes it over — and applying without credentials erases the ones already
+// stored, unrecoverably in the case of the secret.
+//
+// Deleting only deactivates a provider and leaves its credentials behind, so
+// neither check may fire on the configuration this resource itself left
+// behind: after a destroy the provider is inactive, and a customised resource
+// re-supplies the same client ID it had before.
+func socialLoginAdoptionReason(existing fronteggSSO, configuredClientID string) string {
+	if existing.Active {
+		return "it is already active"
+	}
+	if existing.ClientID != "" && configuredClientID == "" {
+		return "it already has credentials, which this configuration does not set and would erase"
+	}
+	return ""
+}
+
 func resourceFronteggSocialLoginCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clientHolder := meta.(*restclient.ClientHolder)
+	providerName := d.Get("provider_name").(string)
+
+	var existing fronteggSSO
+	err := clientHolder.ApiClient.Get(ctx, fmt.Sprintf("%s/%s", fronteggSSOURL, providerName), &existing)
+	switch {
+	case restclient.IsNotFound(err):
+		// Nothing configured for this provider; safe to create.
+	case err != nil:
+		return diag.FromErr(err)
+	default:
+		if reason := socialLoginAdoptionReason(existing, d.Get("client_id").(string)); reason != "" {
+			return diag.Errorf(
+				"social login provider %q cannot be created because %s.\n\n"+
+					"Terraform will not take over a provider configuration it did not create, "+
+					"because applying over one overwrites its settings and can erase credentials "+
+					"that cannot be recovered. To manage the existing configuration, import it:\n\n"+
+					"    terraform import <resource address> %s\n\n"+
+					"Otherwise remove the provider configuration in Frontegg first.",
+				providerName, reason, providerName,
+			)
+		}
+	}
+
 	return resourceFronteggSocialLoginUpdate(ctx, d, meta)
 }
 

--- a/provider/resource_frontegg_social_login.go
+++ b/provider/resource_frontegg_social_login.go
@@ -120,7 +120,11 @@ func resourceFronteggSocialLoginCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceFronteggSocialLoginRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientHolder := meta.(*restclient.ClientHolder)
+	// On import only the ID is set, and the ID is the provider name.
 	providerName := d.Get("provider_name").(string)
+	if providerName == "" {
+		providerName = d.Id()
+	}
 
 	var out fronteggSSO
 	clientHolder.ApiClient.Ignore404()

--- a/provider/resource_frontegg_social_login.go
+++ b/provider/resource_frontegg_social_login.go
@@ -89,13 +89,20 @@ func resourceFronteggSocialLoginDeserialize(d *schema.ResourceData, f fronteggSS
 	if err := d.Set("provider_name", providerName); err != nil {
 		return err
 	}
-	if err := d.Set("client_id", f.ClientID); err != nil {
+	// The API keeps and returns credentials even for a provider that is not
+	// using customised ones. Writing those into state produces permanent drift
+	// against a configuration that deliberately omits them.
+	clientID, secret := f.ClientID, f.Secret
+	if !f.Cusomised {
+		clientID, secret = "", ""
+	}
+	if err := d.Set("client_id", clientID); err != nil {
 		return err
 	}
 	if err := d.Set("redirect_url", f.RedirectURL); err != nil {
 		return err
 	}
-	if err := d.Set("secret", f.Secret); err != nil {
+	if err := d.Set("secret", secret); err != nil {
 		return err
 	}
 	if err := d.Set("customised", f.Cusomised); err != nil {

--- a/provider/resource_frontegg_social_login_test.go
+++ b/provider/resource_frontegg_social_login_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -91,6 +92,75 @@ func TestAccFronteggSocialLogin_lifecycle(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateId:     "facebook",
+			},
+		},
+	})
+}
+
+func TestSocialLoginAdoptionReason(t *testing.T) {
+	tests := []struct {
+		name               string
+		existing           fronteggSSO
+		configuredClientID string
+		wantRefusal        bool
+	}{
+		{
+			name:     "unconfigured provider is free to take",
+			existing: fronteggSSO{Active: false, Cusomised: false},
+		},
+		{
+			name:        "active provider is in use",
+			existing:    fronteggSSO{Active: true},
+			wantRefusal: true,
+		},
+		{
+			name:        "active provider is in use even when we supply credentials",
+			existing:    fronteggSSO{Active: true, ClientID: "theirs"},
+			wantRefusal: true,
+		},
+		{
+			name:        "inactive provider whose credentials we would erase",
+			existing:    fronteggSSO{Active: false, ClientID: "theirs", Cusomised: true},
+			wantRefusal: true,
+		},
+		{
+			// A customised resource re-applied after destroy: inactive, and the
+			// configuration supplies the client ID again. Must not refuse.
+			name:               "inactive provider whose credentials we are resupplying",
+			existing:           fronteggSSO{Active: false, ClientID: "ours", Cusomised: true},
+			configuredClientID: "ours",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := socialLoginAdoptionReason(tt.existing, tt.configuredClientID)
+			if (got != "") != tt.wantRefusal {
+				t.Errorf("reason = %q, wantRefusal = %v", got, tt.wantRefusal)
+			}
+		})
+	}
+}
+
+// The provider this contends with is the one the test just created, so the
+// refusal is exercised without putting a pre-existing configuration at risk.
+const testAccSocialLoginAdopt = testAccSocialLogin + `
+resource "frontegg_social_login" "adopt" {
+  provider_name = "facebook"
+  redirect_url  = "https://tf-acc-adopt.example.com/oauth/callback"
+  customised    = false
+}
+`
+
+func TestAccFronteggSocialLogin_refusesToAdopt(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: testAccSocialLogin},
+			{
+				Config:      testAccSocialLoginAdopt,
+				ExpectError: regexp.MustCompile(`cannot be created because it is already active`),
 			},
 		},
 	})

--- a/provider/resource_frontegg_social_login_test.go
+++ b/provider/resource_frontegg_social_login_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func socialLoginResourceData(t *testing.T, raw map[string]interface{}) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, resourceFronteggSocialLogin().Schema, raw)
+}
+
+// A provider that is not using customised credentials still has credentials on
+// the API side. Copying those into state would fight a configuration that
+// deliberately omits them.
+func TestSocialLoginDeserializeDropsCredentialsWhenNotCustomised(t *testing.T) {
+	d := socialLoginResourceData(t, map[string]interface{}{})
+	in := fronteggSSO{
+		Active:      true,
+		ClientID:    "shared-client-id",
+		Secret:      "shared-secret",
+		RedirectURL: "https://example.com/cb",
+		Cusomised:   false,
+	}
+
+	if err := resourceFronteggSocialLoginDeserialize(d, in, "google"); err != nil {
+		t.Fatalf("deserialize: %v", err)
+	}
+	if got := d.Get("client_id").(string); got != "" {
+		t.Errorf("client_id = %q, want empty", got)
+	}
+	if got := d.Get("secret").(string); got != "" {
+		t.Errorf("secret = %q, want empty", got)
+	}
+	if got := d.Get("redirect_url").(string); got != "https://example.com/cb" {
+		t.Errorf("redirect_url = %q", got)
+	}
+}
+
+func TestSocialLoginDeserializeKeepsCustomisedCredentials(t *testing.T) {
+	d := socialLoginResourceData(t, map[string]interface{}{})
+	in := fronteggSSO{
+		Active:      true,
+		ClientID:    "my-client-id",
+		Secret:      "my-secret",
+		RedirectURL: "https://example.com/cb",
+		Cusomised:   true,
+	}
+
+	if err := resourceFronteggSocialLoginDeserialize(d, in, "google"); err != nil {
+		t.Fatalf("deserialize: %v", err)
+	}
+	if got := d.Get("client_id").(string); got != "my-client-id" {
+		t.Errorf("client_id = %q, want my-client-id", got)
+	}
+	if got := d.Get("secret").(string); got != "my-secret" {
+		t.Errorf("secret = %q, want my-secret", got)
+	}
+}

--- a/provider/resource_frontegg_social_login_test.go
+++ b/provider/resource_frontegg_social_login_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -57,4 +58,40 @@ func TestSocialLoginDeserializeKeepsCustomisedCredentials(t *testing.T) {
 	if got := d.Get("secret").(string); got != "my-secret" {
 		t.Errorf("secret = %q, want my-secret", got)
 	}
+}
+
+// facebook is deliberately chosen: it is the provider least likely to already
+// be configured, so the test does not overwrite live credentials.
+const testAccSocialLogin = `
+resource "frontegg_social_login" "test" {
+  provider_name = "facebook"
+  redirect_url  = "https://tf-acc.example.com/oauth/callback"
+  customised    = false
+}
+`
+
+func TestAccFronteggSocialLogin_lifecycle(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSocialLogin,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_social_login.test", "provider_name", "facebook"),
+					resource.TestCheckResourceAttr("frontegg_social_login.test", "client_id", ""),
+				),
+			},
+			{
+				Config:   testAccSocialLogin,
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      "frontegg_social_login.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "facebook",
+			},
+		},
+	})
 }


### PR DESCRIPTION
Result of sweeping every resource for the import defect found in #261.

Independent of the #258→#261 stack — different files, based on `master`.

## The sweep

Of the 40 resources, 30 use `ImportStatePassthroughContext`. Exactly four have a `Read` that depends on configuration rather than the ID, and **none** send a tenant header in `Read` — so the tenant-scoped resources are clean, `frontegg_role` included (it only sends that header in `Update`).

| Resource | ID is | `Read` keys off | Import |
|---|---|---|---|
| `frontegg_allowed_origin` | the origin | `d.Get("allowed_origin")` | broken |
| `frontegg_email_template` | the template type | `d.Get("template_type")` | broken |
| `frontegg_social_login` | the provider name | `d.Get("provider_name")` | broken |
| `frontegg_admin_portal` | `"admin_portal"` | `d.Get("palette")` | fine — the fetch does not depend on it |

Same shape as `frontegg_user` in #261: the ID *is* the value `Read` needs, but `Read` reads configuration instead, which is empty during an import.

## Two drift bugs had to go first (commit 1)

Neither `allowed_origin` nor `social_login` could reach a clean plan after a successful apply, which made their imports untestable and mattered more than the import bug.

**`allowed_origin` never converged.** The vendors API stores every origin with a trailing slash whatever you submit — send `https://x.example.com`, it stores `https://x.example.com/` — and the comparison was exact. `Read` never found the origin it had just created, cleared the ID, and the next plan recreated it. `Delete` refused with `origin 'x' does not exist` and left the entry behind, so repeated applies accumulated junk. Now compared with the trailing slash normalized away.

**`social_login` never converged** for any provider with credentials on the API side. `Read` copied `client_id` and `secret` into state even when `customised = false`, so a configuration that correctly omits them showed a permanent diff nulling them out. Credentials now only reach state when the provider is customised.

## Then the imports (commit 2)

One-line fallback to `d.Id()` in each of the three `Read` functions.

## Testing

`allowed_origin` and `social_login` get full acceptance tests — create, empty plan, import — run against a real environment. `social_login` deliberately uses `facebook`: see the warning below.

`email_template` gets a read-only check instead. Its `Delete` is a no-op that only drops the resource from state rather than resetting the template, so an acceptance test would permanently alter a shared template. The check drives `Read` with only the ID set, exactly as import does, and mutates nothing. Verified in both directions — it fails without the fix (`read cleared the ID`) and passes with it.

## Warning for anyone running these against a shared environment

`frontegg_social_login` **overwrites whatever is already configured for that provider**, and applying it with `customised = false` and no credentials wipes existing ones. I destroyed the Google configuration in our test environment this way before adding the `facebook` guard — its client ID was recoverable from plan output but the secret was not.

Worth considering separately whether `Create` should refuse when the provider already has a configuration it did not create, rather than silently taking it over.