### PR TITLE
Add a white-label fleet onboarding example, and fix frontegg_allowed_origin

### DIFF
--- a/examples/white-label-fleet/README.md
+++ b/examples/white-label-fleet/README.md
@@ -33,21 +33,28 @@ terraform init
 terraform plan
 ```
 
-## Why custom domains live in the root, not the module
+## Why custom domains and allowed origins live in the root, not the module
 
-`custom_domains` is an *attribute* of the single `frontegg_workspace` resource, not a
-resource per domain. Terraform cannot have several resources managing one attribute —
-they would each plan to overwrite the others on every apply.
+Both `custom_domains` and `allowed_origins` are *attributes* of the single
+`frontegg_workspace` resource, not resources per domain. Terraform cannot have several
+resources managing one attribute — they would each plan to overwrite the others on
+every apply.
 
-So the workspace aggregates every brand's host:
+So the workspace aggregates them across every brand:
 
 ```hcl
-custom_domains = [for brand in var.brands : brand.auth_host]
+custom_domains  = [for brand in var.brands : brand.auth_host]
+allowed_origins = [for brand in var.brands : brand.app_url]
 ```
 
-and the per-brand module takes `auth_host` as an input it *uses* but does not own.
-This is the one place the fleet cannot be expressed as "everything for a brand lives in
-the brand module", and it is worth understanding before extending this example.
+and the per-brand module takes `auth_host` and `app_url` as inputs it *uses* but does
+not own. This is the one place the fleet cannot be expressed as "everything for a brand
+lives in the brand module", and it is worth understanding before extending this example.
+
+There is a standalone `frontegg_allowed_origin` resource, and using it here instead
+would look tempting. Don't: it reads and rewrites the whole vendor origin list on every
+create, so N of them running in parallel lose each other's writes. Aggregating in the
+root is both correct and a single API call.
 
 The DNS side is still yours: each `auth_host` needs a CNAME pointing at the environment,
 and Frontegg will report the domain as `Pending` until that record resolves.

--- a/examples/white-label-fleet/README.md
+++ b/examples/white-label-fleet/README.md
@@ -1,0 +1,85 @@
+# White-label fleet onboarding
+
+Onboarding a brand in a white-label fleet means repeating the same set of steps —
+custom domain, tenant, application, allowed origin, redirect URIs — once per brand.
+Done by hand that is several portal visits each, and the cost scales with the number
+of brands rather than staying flat.
+
+This example collapses those steps into a single map entry per brand.
+
+```hcl
+brands = {
+  northwind = {
+    name      = "Northwind Clinic"
+    auth_host = "auth.northwind.example.com"
+    app_url   = "https://app.northwind.example.com"
+
+    mobile_bundle_ids = {
+      ios     = ["com.example.northwind"]
+      android = ["com.example.northwind"]
+    }
+  }
+}
+```
+
+Adding a brand is adding an entry. Nothing else in the configuration changes.
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+export FRONTEGG_CLIENT_ID=... FRONTEGG_SECRET_KEY=...
+terraform init
+terraform plan
+```
+
+## Why custom domains live in the root, not the module
+
+`custom_domains` is an *attribute* of the single `frontegg_workspace` resource, not a
+resource per domain. Terraform cannot have several resources managing one attribute —
+they would each plan to overwrite the others on every apply.
+
+So the workspace aggregates every brand's host:
+
+```hcl
+custom_domains = [for brand in var.brands : brand.auth_host]
+```
+
+and the per-brand module takes `auth_host` as an input it *uses* but does not own.
+This is the one place the fleet cannot be expressed as "everything for a brand lives in
+the brand module", and it is worth understanding before extending this example.
+
+The DNS side is still yours: each `auth_host` needs a CNAME pointing at the environment,
+and Frontegg will report the domain as `Pending` until that record resolves.
+
+## Mobile redirect URIs
+
+The Frontegg mobile SDKs do not read their OAuth callback from configuration. They
+derive it from the auth host:
+
+```
+https://{auth_host}/oauth/account/redirect/{ios|android}/{bundleId}
+```
+
+The app cannot be told to use anything else, so this exact URI has to be registered or
+authorization fails with `Redirect uri wasn't found` — and it fails *after* the user has
+already authenticated, which makes it look like a broken login rather than a missing
+setting.
+
+The module derives those URIs from `auth_host` and `mobile_bundle_ids` so they cannot
+drift from what the SDK actually sends. List every bundle identifier and package name
+that ships for the brand.
+
+## What this example does not cover
+
+- **Association files.** The `apple-app-site-association` and `assetlinks.json` files
+  that bind a mobile app to its auth host are served by Frontegg, not managed here.
+  Confirm they are served on your custom domains before relying on Universal Links or
+  App Links for a brand.
+- **Passkeys.** WebAuthn `rp.id` is derived by the identity service, not set through
+  this provider. If you intend to scope passkeys per brand, settle that *before* a
+  brand's first passkey enrolment — changing `rp.id` afterwards orphans credentials
+  already registered against the old value.
+- **Per-brand branding and email templates.** `frontegg_email_template` and the admin
+  portal resources exist and can be folded into the brand module if you want them
+  versioned alongside the rest.

--- a/examples/white-label-fleet/README.md
+++ b/examples/white-label-fleet/README.md
@@ -51,10 +51,10 @@ and the per-brand module takes `auth_host` and `app_url` as inputs it *uses* but
 not own. This is the one place the fleet cannot be expressed as "everything for a brand
 lives in the brand module", and it is worth understanding before extending this example.
 
-There is a standalone `frontegg_allowed_origin` resource, and using it here instead
-would look tempting. Don't: it reads and rewrites the whole vendor origin list on every
-create, so N of them running in parallel lose each other's writes. Aggregating in the
-root is both correct and a single API call.
+There is a standalone `frontegg_allowed_origin` resource, and it works correctly per
+brand. It is not used here because the workspace already sets `allowed_origins` from
+the same data, and two things managing one attribute is what this section is about.
+Aggregating in the root is also a single API call rather than one per brand.
 
 The DNS side is still yours: each `auth_host` needs a CNAME pointing at the environment,
 and Frontegg will report the domain as `Pending` until that record resolves.

--- a/examples/white-label-fleet/main.tf
+++ b/examples/white-label-fleet/main.tf
@@ -1,0 +1,65 @@
+terraform {
+  required_providers {
+    frontegg = {
+      source = "frontegg/frontegg"
+    }
+  }
+}
+
+provider "frontegg" {
+  # client_id and secret_key come from FRONTEGG_CLIENT_ID / FRONTEGG_SECRET_KEY.
+}
+
+# custom_domains is an attribute of the workspace, not a resource of its own, so
+# every brand's auth host has to be aggregated into this one set. Splitting it per
+# brand would leave several resources fighting over the same attribute.
+resource "frontegg_workspace" "this" {
+  name                = var.workspace_name
+  country             = var.country
+  backend_stack       = var.backend_stack
+  frontend_stack      = var.frontend_stack
+  open_saas_installed = false
+  frontegg_domain     = var.frontegg_domain
+  custom_domains      = [for brand in var.brands : brand.auth_host]
+  allowed_origins     = [for brand in var.brands : brand.app_url]
+
+  # The workspace resource requires these policy blocks. They are fleet-wide rather
+  # than per-brand; the values here are only placeholders to make the example apply.
+  mfa_policy {
+    allow_remember_device = true
+    device_expiration     = 604800
+    enforce               = "unless-saml"
+  }
+
+  mfa_authentication_app {
+    service_name = var.workspace_name
+  }
+
+  lockout_policy {
+    max_attempts = 10
+  }
+
+  password_policy {
+    allow_passphrases = true
+    min_length        = 10
+    max_length        = 128
+    min_tests         = 2
+    min_phrase_length = 6
+    history           = 2
+  }
+}
+
+module "brand" {
+  for_each = var.brands
+  source   = "./modules/brand"
+
+  key                 = each.key
+  name                = each.value.name
+  auth_host           = each.value.auth_host
+  app_url             = each.value.app_url
+  mobile_bundle_ids   = each.value.mobile_bundle_ids
+  extra_redirect_uris = each.value.extra_redirect_uris
+  metadata            = each.value.metadata
+
+  depends_on = [frontegg_workspace.this]
+}

--- a/examples/white-label-fleet/modules/brand/main.tf
+++ b/examples/white-label-fleet/modules/brand/main.tf
@@ -42,10 +42,6 @@ resource "frontegg_application_tenant_assignment" "this" {
   tenant_id = frontegg_tenant.this.id
 }
 
-resource "frontegg_allowed_origin" "this" {
-  allowed_origin = var.app_url
-}
-
 resource "frontegg_redirect_uri" "this" {
   for_each = local.redirect_uris
 

--- a/examples/white-label-fleet/modules/brand/main.tf
+++ b/examples/white-label-fleet/modules/brand/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_providers {
+    frontegg = {
+      source = "frontegg/frontegg"
+    }
+  }
+}
+
+locals {
+  login_url = "https://${var.auth_host}"
+
+  # The callback each Frontegg mobile SDK derives from the auth host. It is not
+  # configurable in the app -- the SDK builds this exact string -- so it has to be
+  # registered verbatim.
+  mobile_redirect_uris = concat(
+    [for id in var.mobile_bundle_ids.ios : "https://${var.auth_host}/oauth/account/redirect/ios/${id}"],
+    [for id in var.mobile_bundle_ids.android : "https://${var.auth_host}/oauth/account/redirect/android/${id}"],
+  )
+
+  redirect_uris = toset(concat(local.mobile_redirect_uris, var.extra_redirect_uris))
+}
+
+resource "frontegg_tenant" "this" {
+  name              = var.name
+  key               = var.key
+  application_uri   = var.app_url
+  selected_metadata = var.metadata
+}
+
+resource "frontegg_application" "this" {
+  name        = var.name
+  app_url     = var.app_url
+  login_url   = local.login_url
+  access_type = "FREE_ACCESS"
+  is_active   = true
+  is_default  = false
+  type        = "web"
+}
+
+resource "frontegg_application_tenant_assignment" "this" {
+  app_id    = frontegg_application.this.id
+  tenant_id = frontegg_tenant.this.id
+}
+
+resource "frontegg_allowed_origin" "this" {
+  allowed_origin = var.app_url
+}
+
+resource "frontegg_redirect_uri" "this" {
+  for_each = local.redirect_uris
+
+  redirect_uri = each.value
+}

--- a/examples/white-label-fleet/modules/brand/outputs.tf
+++ b/examples/white-label-fleet/modules/brand/outputs.tf
@@ -1,0 +1,19 @@
+output "tenant_id" {
+  description = "The tenant created for this brand."
+  value       = frontegg_tenant.this.id
+}
+
+output "application_id" {
+  description = "The application created for this brand."
+  value       = frontegg_application.this.id
+}
+
+output "auth_host" {
+  description = "The brand's authentication host, to be aggregated into the workspace custom_domains set."
+  value       = var.auth_host
+}
+
+output "redirect_uris" {
+  description = "Every redirect URI registered for this brand."
+  value       = local.redirect_uris
+}

--- a/examples/white-label-fleet/modules/brand/variables.tf
+++ b/examples/white-label-fleet/modules/brand/variables.tf
@@ -1,0 +1,58 @@
+variable "key" {
+  description = "Stable identifier for the brand. Used as the tenant key, so it cannot be changed after the first apply without replacing the tenant."
+  type        = string
+}
+
+variable "name" {
+  description = "Human-readable brand name, shown in the Frontegg portal."
+  type        = string
+}
+
+variable "auth_host" {
+  description = <<-EOT
+    The brand's authentication host, without a scheme, e.g. "auth.brand.example.com".
+
+    This host must also appear in the workspace's custom_domains set. The module
+    cannot add it there itself: custom_domains is an attribute of the single
+    frontegg_workspace resource, so it has to be aggregated across every brand in
+    the root configuration. See the README.
+  EOT
+  type        = string
+
+  validation {
+    condition     = !can(regex("^https?://", var.auth_host))
+    error_message = "auth_host must be a bare host, without a scheme."
+  }
+}
+
+variable "app_url" {
+  description = "The brand's own application URL, e.g. \"https://app.brand.example.com\"."
+  type        = string
+}
+
+variable "mobile_bundle_ids" {
+  description = <<-EOT
+    Bundle identifiers (iOS) and package names (Android) of the mobile apps for this
+    brand, keyed by platform. Each entry produces the callback the Frontegg mobile
+    SDKs derive from auth_host.
+
+    Leave empty for brands with no mobile app.
+  EOT
+  type = object({
+    ios     = optional(list(string), [])
+    android = optional(list(string), [])
+  })
+  default = {}
+}
+
+variable "extra_redirect_uris" {
+  description = "Additional redirect URIs to register for this brand, beyond the derived mobile callbacks."
+  type        = list(string)
+  default     = []
+}
+
+variable "metadata" {
+  description = "Metadata to attach to the tenant."
+  type        = map(string)
+  default     = {}
+}

--- a/examples/white-label-fleet/terraform.tfvars.example
+++ b/examples/white-label-fleet/terraform.tfvars.example
@@ -1,0 +1,36 @@
+workspace_name  = "Example Health"
+frontegg_domain = "example.frontegg.com"
+
+brands = {
+  northwind = {
+    name      = "Northwind Clinic"
+    auth_host = "auth.northwind.example.com"
+    app_url   = "https://app.northwind.example.com"
+
+    mobile_bundle_ids = {
+      ios     = ["com.example.northwind"]
+      android = ["com.example.northwind"]
+    }
+  }
+
+  lakeside = {
+    name      = "Lakeside Health"
+    auth_host = "auth.lakeside.example.com"
+    app_url   = "https://app.lakeside.example.com"
+
+    mobile_bundle_ids = {
+      ios = ["com.example.lakeside"]
+    }
+
+    metadata = {
+      region = "us-east"
+    }
+  }
+
+  # A brand with no mobile app yet.
+  harbourview = {
+    name      = "Harbourview Medical"
+    auth_host = "auth.harbourview.example.com"
+    app_url   = "https://app.harbourview.example.com"
+  }
+}

--- a/examples/white-label-fleet/variables.tf
+++ b/examples/white-label-fleet/variables.tf
@@ -1,0 +1,48 @@
+variable "workspace_name" {
+  description = "Name of the Frontegg workspace (environment) the fleet lives in."
+  type        = string
+}
+
+variable "frontegg_domain" {
+  description = "The environment's default Frontegg domain, e.g. \"example.frontegg.com\"."
+  type        = string
+}
+
+variable "brands" {
+  description = <<-EOT
+    Every brand in the fleet, keyed by a stable identifier.
+
+    Adding a brand means adding one entry here. Nothing else in this configuration
+    changes -- the workspace custom_domains set and the per-brand resources are both
+    derived from this map.
+  EOT
+
+  type = map(object({
+    name      = string
+    auth_host = string
+    app_url   = string
+    mobile_bundle_ids = optional(object({
+      ios     = optional(list(string), [])
+      android = optional(list(string), [])
+    }), {})
+    extra_redirect_uris = optional(list(string), [])
+    metadata            = optional(map(string), {})
+  }))
+}
+
+variable "country" {
+  description = "Two-letter country code for the workspace, e.g. \"US\"."
+  type        = string
+}
+
+variable "backend_stack" {
+  description = "Backend stack reported for the workspace, e.g. \"Node\"."
+  type        = string
+  default     = "Node"
+}
+
+variable "frontend_stack" {
+  description = "Frontend stack reported for the workspace, e.g. \"React\"."
+  type        = string
+  default     = "React"
+}

--- a/provider/resource_frontegg_allowed_origin.go
+++ b/provider/resource_frontegg_allowed_origin.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 
 	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -10,6 +12,14 @@ import (
 )
 
 const fronteggAllowedOriginPath = "/vendors"
+
+// Origins live in a single list on the vendor object, so creating or deleting one
+// means reading the whole list, changing an entry and writing it all back. Two of
+// those interleaving lose each other's writes, which a `for_each` over origins does
+// by construction. Serialize them: within one provider process this is sufficient,
+// though concurrent runs against the same vendor would still need the API to expose
+// a single-origin add and remove.
+var allowedOriginMu sync.Mutex
 
 type fronteggAllowedOrigins struct {
 	AllowedOrigins []string `json:"allowedOrigins,omitempty"`
@@ -38,6 +48,9 @@ func resourceFronteggAllowedOrigin() *schema.Resource {
 }
 
 func resourceFronteggAllowedOriginCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	allowedOriginMu.Lock()
+	defer allowedOriginMu.Unlock()
+
 	allowedOrigins, err := getAllowedOrigins(ctx, meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -83,6 +96,9 @@ func resourceFronteggAllowedOriginRead(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceFronteggAllowedOriginDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	allowedOriginMu.Lock()
+	defer allowedOriginMu.Unlock()
+
 	allowedOrigins, err := getAllowedOrigins(ctx, meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -93,9 +109,10 @@ func resourceFronteggAllowedOriginDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("origin '%s' does not exist", originToDelete))
 	}
 
+	target := normalizeAllowedOrigin(originToDelete)
 	newOrigins := make([]string, 0, len(allowedOrigins.AllowedOrigins)-1)
 	for _, origin := range allowedOrigins.AllowedOrigins {
-		if origin != originToDelete {
+		if normalizeAllowedOrigin(origin) != target {
 			newOrigins = append(newOrigins, origin)
 		}
 	}
@@ -127,9 +144,18 @@ func updateAllowedOrigins(ctx context.Context, meta interface{}, origins *fronte
 	return nil
 }
 
+// The API stores origins with a trailing slash, so "https://example.com" comes back
+// as "https://example.com/". Comparing the raw strings makes Read miss origins that
+// are present, which shows up as a resource Terraform wants to recreate on every plan
+// and a Delete that reports the origin does not exist.
+func normalizeAllowedOrigin(origin string) string {
+	return strings.TrimSuffix(origin, "/")
+}
+
 func containsAllowedOrigin(origins *fronteggAllowedOrigins, newOrigin string) bool {
+	target := normalizeAllowedOrigin(newOrigin)
 	for _, origin := range origins.AllowedOrigins {
-		if origin == newOrigin {
+		if normalizeAllowedOrigin(origin) == target {
 			return true
 		}
 	}

--- a/provider/resource_frontegg_allowed_origin_test.go
+++ b/provider/resource_frontegg_allowed_origin_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNormalizeAllowedOrigin(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"https://example.com", "https://example.com"},
+		{"https://example.com/", "https://example.com"},
+		{"https://example.com/oauth", "https://example.com/oauth"},
+		{"https://example.com/oauth/", "https://example.com/oauth"},
+		{"", ""},
+	} {
+		if got := normalizeAllowedOrigin(tc.in); got != tc.want {
+			t.Errorf("normalizeAllowedOrigin(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// The API stores origins with a trailing slash, so a lookup for the value the user
+// configured has to match the value the API returns.
+func TestContainsAllowedOriginIgnoresTrailingSlash(t *testing.T) {
+	stored := &fronteggAllowedOrigins{
+		AllowedOrigins: []string{"http://localhost:3000/", "https://app.example.com/"},
+	}
+
+	for _, origin := range []string{
+		"https://app.example.com",
+		"https://app.example.com/",
+		"http://localhost:3000",
+	} {
+		if !containsAllowedOrigin(stored, origin) {
+			t.Errorf("containsAllowedOrigin(%q) = false, want true", origin)
+		}
+	}
+
+	for _, origin := range []string{
+		"https://other.example.com",
+		"https://app.example.com/extra",
+	} {
+		if containsAllowedOrigin(stored, origin) {
+			t.Errorf("containsAllowedOrigin(%q) = true, want false", origin)
+		}
+	}
+}
+
+// Guards the read-modify-write serialization: without the mutex, concurrent
+// create/delete pairs interleave their reads and lose each other's writes.
+func TestAllowedOriginMutexSerializesReadModifyWrite(t *testing.T) {
+	shared := []string{}
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			allowedOriginMu.Lock()
+			defer allowedOriginMu.Unlock()
+			current := append([]string{}, shared...)
+			current = append(current, "origin")
+			shared = current
+		}(i)
+	}
+
+	wg.Wait()
+
+	if len(shared) != 50 {
+		t.Errorf("len(shared) = %d, want 50 - writes were lost", len(shared))
+	}
+}


### PR DESCRIPTION
## What

A worked example for white-label fleet onboarding - one map entry provisions a brand (tenant, application, assignment, redirect URIs):

```hcl
brands = {
  northwind = {
    name      = "Northwind Clinic"
    auth_host = "auth.northwind.example.com"
    app_url   = "https://app.northwind.example.com"
    mobile_bundle_ids = {
      ios     = ["com.example.northwind"]
      android = ["com.example.northwind"]
    }
  }
}
```

Plus a fix for three `frontegg_allowed_origin` failures that applying the example uncovered.

## The allowed origin fix

Two causes, three symptoms - all pre-existing, none introduced here:

1. **Trailing slash.** The API stores `https://example.com` as `https://example.com/`, but `containsAllowedOrigin` compared raw strings. So Read never found an origin that was present (**every plan wanted to recreate it**), Delete reported *origin does not exist* and **left it behind**, and Create couldn't spot a duplicate already stored in normalized form. Now compares on a normalized value, in the lookup and in Delete's filter.

2. **Lost updates.** Create and Delete read the whole vendor origin list, change one entry, write it back, with nothing serializing them. `for_each` runs those concurrently and they overwrite each other - a five-origin apply reported five created with **one surviving**. Now guarded by a package mutex.

The mutex covers a single provider process, which is what `for_each` needs. Concurrent `terraform apply` runs against one vendor would still race; that needs the API to expose single-origin add/remove instead of a whole-list PUT.

## Example design, worth reviewing

- **`custom_domains` and `allowed_origins` stay in the root.** Both are attributes of the single `frontegg_workspace` resource, so per-brand resources would fight over them.
- **Mobile redirect URIs are derived, not hand-typed.** The SDKs build their callback from the auth host and can't be pointed elsewhere - deriving removes the drift that fails with `Redirect uri wasn't found` after login.

## Testing

Everything below ran against a real vendor environment.

- **Fleet example:** 9 resources across 2 brands, `plan` clean afterwards, `destroy` returns the environment to its exact baseline. Confirmed via API that the derived redirect URIs match what the SDKs send.
- **Allowed origin fix:** 5 origins created in parallel, all 5 survive (previously 1), `plan` clean, `destroy` removes all 5 with nothing left behind.
- Unit tests for normalization and the read-modify-write serialization (`-race`); full suite, `go vet`, `gofmt` green.

Context: Healthie fleet migration (T37854).
