### PR TITLE
Build with Go 1.25.13 to clear the stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/frontegg/terraform-provider-frontegg
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0


### PR DESCRIPTION
NICE Actimize's scan of the published **v2.9.1** artifact reports 11 findings (10 high) against `stdlib v1.25.11`.

## What this is

Not a dependency vulnerability. `stdlib` is the Go standard library compiled into the binary, and its version is whichever toolchain built it. Our `go.mod` says `go 1.25.11`, and `release.yml` passes `go-version-file: go.mod` to `setup-go` — so the release is built on exactly 1.25.11, which is exactly what their scanner reports.

No provider code is involved and no module is at fault. The only fix is to rebuild on a patched toolchain.

## The change

`go.mod`: `go 1.25.11` → `go 1.25.13`. One line.

1.25.13 is the earliest patch listed as fixing every CVE in their report, and it keeps us on the same minor line. 1.26.6 also qualifies if we would rather move up; I picked the smaller step.

## Confirmation the previous release worked

Their earlier scan flagged gRPC (GHSA-hrxh-6v49-42gf). That finding is **absent** from this report, which confirms v2.9.1 cleared it. This is a genuinely new class of finding, not a regression.

## Caveat

Their screenshot shows `TOTAL: 11` but only 6 rows are visible. All 6 list `1.25.13, 1.26.6, 1.27.0-rc.3` as fixed versions, so 1.25.13 covers everything I can see. Worth getting the full table from them before we call it closed, in case a hidden row needs the 1.26 line.

## Testing

Build, unit tests, `go vet`, `gofmt` and `go mod tidy` all pass under the new directive. There is no code change to exercise beyond that — the real verification is the scan against the next published artifact.

## Follow-up worth considering

This will recur with every Go patch release. Dependabot does not track the toolchain the same way it tracks modules, so nothing will open this PR for us next time. Either a periodic rebuild-and-release cadence or a scheduled job that bumps the `go` directive would stop us finding out from a customer.