### PR TITLE
Optionally register the redirect URIs an app registration implies

### DIFF
--- a/docs/resources/associated_domain.md
+++ b/docs/resources/associated_domain.md
@@ -53,6 +53,7 @@ resource "frontegg_associated_domain" "android" {
 - `app_id` (String) The iOS app identifier in `{teamId}.{bundleId}` form, as published in the `apple-app-site-association` file. iOS only.
 - `package_name` (String) The Android application package name, as published in `assetlinks.json`. Android only.
 - `sha256_cert_fingerprints` (List of String) SHA-256 signing-certificate fingerprints of the Android app. Include every certificate the app ships under (debug, release, Play App Signing).
+- `sync_redirect_uris` (Boolean) Whether to register the OAuth redirect URIs this app implies after changing the registration. The Frontegg mobile SDKs derive their callback from the auth host, and it has to be allow-listed or authorization fails after the user has already signed in. Leaving this off means registering that URI separately, with `frontegg_redirect_uri` or by hand. Off by default because it depends on a sync endpoint that is not available in every environment yet; where it is missing the sync is skipped with a warning rather than failing the apply.
 
 ### Read-Only
 

--- a/provider/resource_frontegg_associated_domain.go
+++ b/provider/resource_frontegg_associated_domain.go
@@ -13,6 +13,7 @@ import (
 )
 
 const fronteggAssociatedDomainPath = "/vendors/resources/associated-domains/v1"
+const fronteggAppRedirectSyncPath = "/oauth/resources/configurations/v1/redirect-uri/sync"
 
 // The API exposes no update: the documented path is delete-and-recreate, which
 // is why every attribute below is ForceNew.
@@ -42,6 +43,10 @@ callbacks, magic links, password resets and passkeys.`,
 
 		CreateContext: resourceFronteggAssociatedDomainCreate,
 		ReadContext:   resourceFronteggAssociatedDomainRead,
+		// Every attribute the API knows about is ForceNew; sync_redirect_uris is
+		// local behaviour, so changing it needs an update that does no API work
+		// rather than a destroy and recreate of the registration.
+		UpdateContext: resourceFronteggAssociatedDomainRead,
 		DeleteContext: resourceFronteggAssociatedDomainDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceFronteggAssociatedDomainImport,
@@ -77,6 +82,17 @@ callbacks, magic links, password resets and passkeys.`,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"sync_redirect_uris": {
+				Description: "Whether to register the OAuth redirect URIs this app implies after changing the registration. " +
+					"The Frontegg mobile SDKs derive their callback from the auth host, and it has to be allow-listed or " +
+					"authorization fails after the user has already signed in. Leaving this off means registering that URI " +
+					"separately, with `frontegg_redirect_uri` or by hand. " +
+					"Off by default because it depends on a sync endpoint that is not available in every environment yet; " +
+					"where it is missing the sync is skipped with a warning rather than failing the apply.",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 		},
 	}
@@ -152,7 +168,7 @@ func resourceFronteggAssociatedDomainCreate(ctx context.Context, d *schema.Resou
 
 	if id := out.configurationId(); id != "" {
 		d.SetId(id)
-		return nil
+		return syncAppRedirectUris(ctx, d, clientHolder)
 	}
 
 	// The create response did not carry an id; find the configuration in the list.
@@ -163,10 +179,39 @@ func resourceFronteggAssociatedDomainCreate(ctx context.Context, d *schema.Resou
 	for _, c := range configs {
 		if resourceFronteggAssociatedDomainMatches(d, c) {
 			d.SetId(c.configurationId())
-			return nil
+			return syncAppRedirectUris(ctx, d, clientHolder)
 		}
 	}
 	return diag.Errorf("associated domain configuration was created but could not be found afterwards")
+}
+
+// Registering an app changes the association files Frontegg serves, and the OAuth
+// redirect URIs the mobile SDKs use are derived from those. Asking the service to
+// reconcile here keeps the two in step; without it the URI is registered whenever
+// the vendor configuration next changes, which may be long after the app ships.
+func syncAppRedirectUris(
+	ctx context.Context,
+	d *schema.ResourceData,
+	clientHolder *restclient.ClientHolder,
+) diag.Diagnostics {
+	if !d.Get("sync_redirect_uris").(bool) {
+		return nil
+	}
+
+	if err := clientHolder.ApiClient.Post(ctx, fronteggAppRedirectSyncPath, struct{}{}, nil); err != nil {
+		if restclient.IsNotFound(err) {
+			return diag.Diagnostics{{
+				Severity: diag.Warning,
+				Summary:  "Redirect URI sync is not available in this environment",
+				Detail: "The associated domain was registered, but the OAuth redirect URIs it implies were not, " +
+					"because this environment does not expose the sync endpoint. Register them with " +
+					"frontegg_redirect_uri, or set sync_redirect_uris = false to silence this.",
+			}}
+		}
+		return diag.FromErr(err)
+	}
+
+	return nil
 }
 
 func resourceFronteggAssociatedDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -211,7 +256,11 @@ func resourceFronteggAssociatedDomainDelete(ctx context.Context, d *schema.Resou
 	if err != nil && !restclient.IsNotFound(err) {
 		return diag.FromErr(err)
 	}
-	return nil
+
+	// Reconciliation only adds URIs, so this does not withdraw the callback for the
+	// app just removed. It keeps the sync point consistent with create, and picks up
+	// anything else the association files still publish.
+	return syncAppRedirectUris(ctx, d, clientHolder)
 }
 
 // Import expects "{platform}/{configurationId}", because the API namespaces

--- a/provider/resource_frontegg_associated_domain_test.go
+++ b/provider/resource_frontegg_associated_domain_test.go
@@ -87,6 +87,16 @@ func TestAssociatedDomainMatches(t *testing.T) {
 	}
 }
 
+func TestSyncRedirectUrisDefaultsOff(t *testing.T) {
+	d := associatedDomainResourceData(t, map[string]interface{}{
+		"platform": "ios",
+		"app_id":   "ABCDE12345.com.example.app",
+	})
+	if d.Get("sync_redirect_uris").(bool) {
+		t.Error("sync_redirect_uris should default to false, so the resource works where the endpoint is absent")
+	}
+}
+
 func TestAssociatedDomainImportIdParsing(t *testing.T) {
 	for _, tc := range []struct {
 		id           string


### PR DESCRIPTION
Follow-up to #265. Pairs with frontegg/oauth-service#848.

## Why

Registering a mobile app changes the association files Frontegg serves, and the OAuth redirect URIs the mobile SDKs use are derived from those files. Leaving them out of step is the exact failure this resource exists to avoid - authorization fails with `Redirect uri wasn't found` **after** the user has already signed in.

## What

Adds `sync_redirect_uris`, which asks the service to reconcile the allow-list against the published association files after the registration changes:

```hcl
resource "frontegg_associated_domain" "ios" {
  platform           = "ios"
  app_id             = "ABCDE12345.com.example.app"
  sync_redirect_uris = true
}
```

**Off by default**, deliberately: it calls a sync endpoint that isn't deployed everywhere yet (oauth-service#848). Where it's missing the resource emits a warning and the apply still succeeds, rather than failing on an endpoint the environment never had.

`sync_redirect_uris` is the one non-`ForceNew` attribute, so toggling it needs an update rather than destroying and recreating the registration. The added `UpdateContext` does no API work.

## Verified against a real environment

With the endpoint absent - which is production today:

```
Warning: Redirect URI sync is not available in this environment
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

The registration is created, the warning explains what wasn't done, and `destroy` removes it cleanly. Build, vet, gofmt and the full suite pass; docs regenerated.

Once #848 ships I'll re-run this against an environment with the endpoint enabled to confirm the success path.

Context: Healthie fleet migration (T37854 / FR-26227).
