### PR TITLE
FR-26734 Cover frontegg-application-id on MFA requests and document it

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,15 @@ portal. To configure multiple environments you will need to configure multiple
 copies of provider with one environment ID per each. If no environment ID was
 provided the configuration will be cross-environments.
 
+If MFA is configured per application in your environment, set `application_id` to
+the ID of the application whose configuration you want to manage. The provider
+sends it as the `frontegg-application-id` header on every request, so the
+`mfa_policy` and `mfa_authentication_app` settings on `frontegg_workspace` and the
+`frontegg_tenant_mfa_policy` resource are read and written against that
+application. Without it, those calls are not scoped to an application. Since the
+header applies to every request, configure one copy of the provider per
+application.
+
 ## Example Usage
 
 ```terraform
@@ -56,7 +65,7 @@ If you're upgrading from v1.0.x to v2.0.0, please see the [Migration Guide](guid
 ### Optional
 
 - `api_base_url` (String) The Frontegg api url. Override to change region. Defaults to EU url.
-- `application_id` (String) The application ID for multi-application support. When set, adds frontegg-application-id header to all requests.
+- `application_id` (String) The application ID for multi-application support. When set, adds the frontegg-application-id header to all requests. Set this in environments where MFA is configured per application, so that MFA policy and authentication app settings are read and written against that application.
 - `environment_id` (String, Sensitive) The client ID from environment settings.
 - `portal_base_url` (String) The Frontegg portal url. Override to change region. Defaults to EU url.
 

--- a/docs/resources/tenant_mfa_policy.md
+++ b/docs/resources/tenant_mfa_policy.md
@@ -6,6 +6,8 @@ description: |-
   Configures the MFA policy for a Frontegg tenant.
   This is a singleton resource per tenant. You must only create one frontegg_tenant_mfa_policy resource
   per tenant.
+  In environments where MFA is configured per application, set application_id on the provider so that this
+  policy is read and written against that application.
   Note: This resource cannot be deleted. When destroyed, Terraform will remove it from the state file, but the MFA policy will remain in its last-applied state.
 ---
 
@@ -15,6 +17,9 @@ Configures the MFA policy for a Frontegg tenant.
 
 This is a singleton resource per tenant. You must only create one frontegg_tenant_mfa_policy resource
 per tenant.
+
+In environments where MFA is configured per application, set `application_id` on the provider so that this
+policy is read and written against that application.
 
 **Note:** This resource cannot be deleted. When destroyed, Terraform will remove it from the state file, but the MFA policy will remain in its last-applied state.
 

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -115,7 +115,7 @@ resource "frontegg_workspace" "example" {
 
     The domain must end with ".frontegg.com" or ".us.frontegg.com".
 - `frontend_stack` (String) The frontend stack of the application associated with the worksapce.
-- `mfa_policy` (Block List, Min: 1, Max: 1) Configures the multi-factor authentication (MFA) policy. (see [below for nested schema](#nestedblock--mfa_policy))
+- `mfa_policy` (Block List, Min: 1, Max: 1) Configures the multi-factor authentication (MFA) policy. In environments where MFA is configured per application, set `application_id` on the provider so that this policy is read and written against that application. (see [below for nested schema](#nestedblock--mfa_policy))
 - `name` (String) The name of the workspace.
 - `open_saas_installed` (Boolean) Whether the application associated with the workspace has OpenSaaS installed.
 - `password_policy` (Block List, Min: 1, Max: 1) Configures the password policy. (see [below for nested schema](#nestedblock--password_policy))
@@ -127,7 +127,7 @@ resource "frontegg_workspace" "example" {
 				You must configure CNAME for each domain, you can get record values from the portal.
 - `hosted_login` (Block List, Max: 1) Configures Frontegg-hosted OAuth login. (see [below for nested schema](#nestedblock--hosted_login))
 - `lockout_policy` (Block List, Max: 1) Configures the user lockout policy. (see [below for nested schema](#nestedblock--lockout_policy))
-- `mfa_authentication_app` (Block List, Max: 1) Configures the multi-factor authentication (MFA) via an authentication app. (see [below for nested schema](#nestedblock--mfa_authentication_app))
+- `mfa_authentication_app` (Block List, Max: 1) Configures the multi-factor authentication (MFA) via an authentication app. In environments where MFA is configured per application, set `application_id` on the provider so that this configuration is read and written against that application. (see [below for nested schema](#nestedblock--mfa_authentication_app))
 - `oidc` (Block List, Max: 1) Configures SSO via OIDC. (see [below for nested schema](#nestedblock--oidc))
 - `saml` (Block List, Max: 1) Configures SSO via SAML. (see [below for nested schema](#nestedblock--saml))
 - `sso_multi_tenant_policy` (Block List, Max: 1) Configures how multiple tenants can claim the same SSO domain. (see [below for nested schema](#nestedblock--sso_multi_tenant_policy))

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -50,7 +50,7 @@ func New(version string) func() *schema.Provider {
 					Sensitive:   true,
 				},
 				"application_id": {
-					Description: "The application ID for multi-application support. When set, adds frontegg-application-id header to all requests.",
+					Description: "The application ID for multi-application support. When set, adds the frontegg-application-id header to all requests. Set this in environments where MFA is configured per application, so that MFA policy and authentication app settings are read and written against that application.",
 					Type:        schema.TypeString,
 					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc("FRONTEGG_APPLICATION_ID", nil),

--- a/provider/resource_frontegg_mfa_application_id_test.go
+++ b/provider/resource_frontegg_mfa_application_id_test.go
@@ -1,0 +1,116 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/frontegg/terraform-provider-frontegg/internal/restclient"
+)
+
+type capturedMFARequest struct {
+	method string
+	path   string
+	header http.Header
+}
+
+func exerciseMFARequests(t *testing.T, applicationID string) []capturedMFARequest {
+	t.Helper()
+
+	var (
+		mu       sync.Mutex
+		captured []capturedMFARequest
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		captured = append(captured, capturedMFARequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			header: r.Header.Clone(),
+		})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("writing response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := restclient.MakeRestClient(srv.URL, "", applicationID)
+	client.Authenticate("test-token")
+
+	ctx := context.Background()
+	tenantHeaders := http.Header{}
+	tenantHeaders.Add("frontegg-tenant-id", "tenant-1")
+
+	if _, err := getMFAPolicy(ctx, &client, nil); err != nil {
+		t.Fatalf("getMFAPolicy (workspace): %v", err)
+	}
+	if _, err := getMFAPolicy(ctx, &client, tenantHeaders); err != nil {
+		t.Fatalf("getMFAPolicy (tenant): %v", err)
+	}
+	if err := writeMFAPolicy(ctx, &client, nil, fronteggMFAPolicy{}); err != nil {
+		t.Fatalf("writeMFAPolicy (workspace): %v", err)
+	}
+	if err := writeMFAPolicy(ctx, &client, tenantHeaders, fronteggMFAPolicy{}); err != nil {
+		t.Fatalf("writeMFAPolicy (tenant): %v", err)
+	}
+
+	var out fronteggMFA
+	if err := client.Get(ctx, fronteggMFAURL, &out); err != nil {
+		t.Fatalf("get authentication app config: %v", err)
+	}
+	if err := client.Post(ctx, fronteggMFAURL, fronteggMFA{}, nil); err != nil {
+		t.Fatalf("post authentication app config: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	return append([]capturedMFARequest(nil), captured...)
+}
+
+func TestMFARequestsSendApplicationIDHeader(t *testing.T) {
+	captured := exerciseMFARequests(t, "app-123")
+
+	if len(captured) != 6 {
+		t.Fatalf("captured %d requests, want 6", len(captured))
+	}
+	for _, req := range captured {
+		if req.path != fronteggMFAPolicyURL && req.path != fronteggMFAURL {
+			t.Errorf("unexpected path %q", req.path)
+		}
+		if got := req.header.Get("frontegg-application-id"); got != "app-123" {
+			t.Errorf("%s %s: frontegg-application-id = %q, want %q", req.method, req.path, got, "app-123")
+		}
+	}
+}
+
+func TestMFATenantScopedRequestsKeepBothHeaders(t *testing.T) {
+	captured := exerciseMFARequests(t, "app-123")
+
+	tenantScoped := 0
+	for _, req := range captured {
+		if req.header.Get("frontegg-tenant-id") == "" {
+			continue
+		}
+		tenantScoped++
+		if got := req.header.Get("frontegg-application-id"); got != "app-123" {
+			t.Errorf("%s %s: frontegg-application-id = %q, want %q", req.method, req.path, got, "app-123")
+		}
+	}
+	if tenantScoped != 2 {
+		t.Fatalf("%d tenant-scoped requests, want 2", tenantScoped)
+	}
+}
+
+func TestMFARequestsOmitApplicationIDHeaderWhenUnset(t *testing.T) {
+	captured := exerciseMFARequests(t, "")
+
+	for _, req := range captured {
+		if got := req.header.Get("frontegg-application-id"); got != "" {
+			t.Errorf("%s %s: frontegg-application-id = %q, want it unset", req.method, req.path, got)
+		}
+	}
+}

--- a/provider/resource_frontegg_tenant_mfa_policy.go
+++ b/provider/resource_frontegg_tenant_mfa_policy.go
@@ -29,6 +29,9 @@ func resourceFronteggTenantMFAPolicy() *schema.Resource {
 This is a singleton resource per tenant. You must only create one frontegg_tenant_mfa_policy resource
 per tenant.
 
+In environments where MFA is configured per application, set ` + "`application_id`" + ` on the provider so that this
+policy is read and written against that application.
+
 **Note:** This resource cannot be deleted. When destroyed, Terraform will remove it from the state file, but the MFA policy will remain in its last-applied state.`,
 
 		CreateContext: resourceFronteggTenantMFAPolicyCreate,

--- a/provider/resource_frontegg_workspace.go
+++ b/provider/resource_frontegg_workspace.go
@@ -331,7 +331,7 @@ per Frontegg provider.
 				Required: true,
 			},
 			"mfa_policy": {
-				Description: "Configures the multi-factor authentication (MFA) policy.",
+				Description: "Configures the multi-factor authentication (MFA) policy. In environments where MFA is configured per application, set `application_id` on the provider so that this policy is read and written against that application.",
 				Type:        schema.TypeList,
 				Required:    true,
 				MinItems:    1,
@@ -360,7 +360,7 @@ Must be one of "off", "on", or "unless-saml".`,
 				},
 			},
 			"mfa_authentication_app": {
-				Description: "Configures the multi-factor authentication (MFA) via an authentication app.",
+				Description: "Configures the multi-factor authentication (MFA) via an authentication app. In environments where MFA is configured per application, set `application_id` on the provider so that this configuration is read and written against that application.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -27,6 +27,15 @@ portal. To configure multiple environments you will need to configure multiple
 copies of provider with one environment ID per each. If no environment ID was
 provided the configuration will be cross-environments.
 
+If MFA is configured per application in your environment, set `application_id` to
+the ID of the application whose configuration you want to manage. The provider
+sends it as the `frontegg-application-id` header on every request, so the
+`mfa_policy` and `mfa_authentication_app` settings on `frontegg_workspace` and the
+`frontegg_tenant_mfa_policy` resource are read and written against that
+application. Without it, those calls are not scoped to an application. Since the
+header applies to every request, configure one copy of the provider per
+application.
+
 ## Example Usage
 
 {{tffile "examples/provider/provider.tf"}}


### PR DESCRIPTION
Closes [FR-26734](https://frontegg.atlassian.net/browse/FR-26734).

## Finding: the header was already being sent

The ticket says "Most of those calls have no `frontegg-application-id`". That reads as true from the MFA call sites, which pass `nil` headers — but the header is not set per call site. The REST client sets it on **every** request when the provider's `application_id` is configured (`internal/restclient/restclient.go`), and has since #218. The `nil` at the MFA call sites only means "no tenant scoping".

So AC #1 already held. This PR locks it in with a test instead of changing behavior, and adds the docs from AC #2. No production code paths change.

## Verified against a real environment

Read-only check against a live environment with four applications, authenticating once per application ID:

- `GET /identity/resources/configurations/v1/mfa-policy` returns a **different policy `id` for each application**, and a different one again with no `application_id` set. That is end-to-end proof that the header leaves the provider and that Identity honours it for MFA policy.
- Vendor auth succeeds with the header present, so sending it on `/auth/vendor` is not a regression.
- `GET /identity/resources/configurations/v1/mfa` (authenticator app) returned an identical payload for every application. The response has no id to distinguish by and every application is on defaults here, so this is inconclusive rather than negative — worth confirming with Identity whether that endpoint is per-application at all. Telling them apart would need a write to a real environment, which I did not do.

## Test

`provider/resource_frontegg_mfa_application_id_test.go` drives the actual functions the resources call — `getMFAPolicy`, `writeMFAPolicy`, and the workspace `GET`/`POST` on `fronteggMFAURL` — against an `httptest` server:

- all six MFA request shapes carry `frontegg-application-id` (workspace and tenant-scoped policy reads and writes, plus authenticator app read and write);
- a caller's `frontegg-tenant-id` survives — the client `Set`s its own headers *after* `Add`ing caller headers, so this was the one real clobbering risk;
- no header is sent when `application_id` is unset.

## Docs

`application_id` is now documented as the way to target MFA-per-application environments: on the provider index page (including the caveat that the header applies to every request, so you need one provider copy per application), on the workspace `mfa_policy` and `mfa_authentication_app` blocks, and on `frontegg_tenant_mfa_policy`.

Docs regenerated with `tfplugindocs`. Note for reviewers: the default provider-name inference is wrong inside a git worktree and rewrites `page_title` across all 44 doc files — regenerate with `--provider-name terraform-provider-frontegg`.

Out of scope per the ticket: new MFA resources, per-app resource schema, Identity or API Gateway changes.

[FR-26734]: https://frontegg.atlassian.net/browse/FR-26734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ