### PR TITLE
FR-26867 Stop rejecting tenantId in JWT template claims

### DIFF
--- a/docs/resources/jwt_template.md
+++ b/docs/resources/jwt_template.md
@@ -22,15 +22,22 @@ resource "frontegg_jwt_template" "example" {
 
   # Frontegg requires the standard OIDC claims (iss, sub, aud, exp, iat) in every
   # template, where aud must be {{clientId}} or {{applicationId}}. Additional
-  # custom claims may be added alongside them. Claims reserved for internal use
-  # (e.g. type, tenantId) are populated by Frontegg and must not be set here.
+  # custom claims may be added alongside them.
+  #
+  # Claims are NOT auto-populated: whatever this map contains is what the token
+  # carries. In particular, set tenantId yourself if your application or the
+  # Frontegg frontend SDK expects it — tokens issued without it break the SDK.
+  #
+  # A small set of claims is reserved for internal use and rejected by the API
+  # (for example type, userId, superUser, act, amr, acr, auth_time, nonce).
   claims = {
-    iss   = "{{iss}}"
-    sub   = "{{sub}}"
-    aud   = "{{clientId}}"
-    exp   = "{{exp}}"
-    iat   = "{{iat}}"
-    email = "{{user.email}}"
+    iss      = "{{iss}}"
+    sub      = "{{sub}}"
+    aud      = "{{clientId}}"
+    exp      = "{{exp}}"
+    iat      = "{{iat}}"
+    tenantId = "{{user.tenantId}}"
+    email    = "{{user.email}}"
   }
 }
 ```
@@ -41,7 +48,7 @@ resource "frontegg_jwt_template" "example" {
 ### Required
 
 - `algorithm` (String) The JWT signing algorithm. Valid values are `RS256` and `HS256`.
-- `claims` (Map of String) Key-value pairs representing the JWT claims included in the template.
+- `claims` (Map of String) Key-value pairs representing the JWT claims included in the template. Claims are not auto-populated: the token carries exactly what is set here, so include `tenantId` if your application or the Frontegg frontend SDK expects it. The standard OIDC claims (`iss`, `sub`, `aud`, `exp`, `iat`) are required, where `aud` must be `{{clientId}}` or `{{applicationId}}`. A small set of claims is reserved for internal use and rejected by the API (for example `type`, `userId`, `superUser`, `act`, `amr`, `acr`, `auth_time`, `nonce`).
 - `expiration` (Number) The token expiration time in seconds.
 - `key` (String) A unique identifier key for the JWT template.
 - `name` (String) A human-readable name for the JWT template.

--- a/examples/resources/frontegg_jwt_template/resource.tf
+++ b/examples/resources/frontegg_jwt_template/resource.tf
@@ -7,14 +7,21 @@ resource "frontegg_jwt_template" "example" {
 
   # Frontegg requires the standard OIDC claims (iss, sub, aud, exp, iat) in every
   # template, where aud must be {{clientId}} or {{applicationId}}. Additional
-  # custom claims may be added alongside them. Claims reserved for internal use
-  # (e.g. type, tenantId) are populated by Frontegg and must not be set here.
+  # custom claims may be added alongside them.
+  #
+  # Claims are NOT auto-populated: whatever this map contains is what the token
+  # carries. In particular, set tenantId yourself if your application or the
+  # Frontegg frontend SDK expects it — tokens issued without it break the SDK.
+  #
+  # A small set of claims is reserved for internal use and rejected by the API
+  # (for example type, userId, superUser, act, amr, acr, auth_time, nonce).
   claims = {
-    iss   = "{{iss}}"
-    sub   = "{{sub}}"
-    aud   = "{{clientId}}"
-    exp   = "{{exp}}"
-    iat   = "{{iat}}"
-    email = "{{user.email}}"
+    iss      = "{{iss}}"
+    sub      = "{{sub}}"
+    aud      = "{{clientId}}"
+    exp      = "{{exp}}"
+    iat      = "{{iat}}"
+    tenantId = "{{user.tenantId}}"
+    email    = "{{user.email}}"
   }
 }

--- a/provider/resource_frontegg_jwt_template.go
+++ b/provider/resource_frontegg_jwt_template.go
@@ -20,11 +20,6 @@ const fronteggJWTTemplatePath = "/identity/resources/jwt-templates/v1"
 // See https://developers.frontegg.com/ciam/guides/security-center/token-management/claims
 var fronteggJWTTemplateRequiredClaims = []string{"iss", "sub", "aud", "exp", "iat"}
 
-// fronteggJWTTemplateReservedClaims are claims Frontegg populates internally and
-// rejects when supplied in a template ("Claims reserved for internal use are not
-// allowed"). We reject them at plan time so the failure surfaces before apply.
-var fronteggJWTTemplateReservedClaims = []string{"type", "tenantId"}
-
 type fronteggJWTTemplateSchema struct {
 	Claims map[string]interface{} `json:"claims"`
 }
@@ -86,9 +81,15 @@ func resourceFronteggJWTTemplate() *schema.Resource {
 				}, false),
 			},
 			"claims": {
-				Description: "Key-value pairs representing the JWT claims included in the template.",
-				Type:        schema.TypeMap,
-				Required:    true,
+				Description: "Key-value pairs representing the JWT claims included in the template. " +
+					"Claims are not auto-populated: the token carries exactly what is set here, so " +
+					"include `tenantId` if your application or the Frontegg frontend SDK expects it. " +
+					"The standard OIDC claims (`iss`, `sub`, `aud`, `exp`, `iat`) are required, where " +
+					"`aud` must be `{{clientId}}` or `{{applicationId}}`. A small set of claims is " +
+					"reserved for internal use and rejected by the API (for example `type`, `userId`, " +
+					"`superUser`, `act`, `amr`, `acr`, `auth_time`, `nonce`).",
+				Type:     schema.TypeMap,
+				Required: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -128,13 +129,6 @@ func resourceFronteggJWTTemplateValidateClaims(_ context.Context, d *schema.Reso
 			strings.Join(missing, ", "),
 		)
 	}
-	if reserved := presentReservedClaims(claims); len(reserved) > 0 {
-		return fmt.Errorf(
-			"jwt template claims must not include claims reserved for internal use by Frontegg (%s); remove: %s",
-			strings.Join(fronteggJWTTemplateReservedClaims, ", "),
-			strings.Join(reserved, ", "),
-		)
-	}
 	return nil
 }
 
@@ -148,18 +142,6 @@ func missingRequiredClaims(claims map[string]interface{}) []string {
 		}
 	}
 	return missing
-}
-
-// presentReservedClaims returns the reserved claims present in the given claims
-// map, preserving the canonical order of fronteggJWTTemplateReservedClaims.
-func presentReservedClaims(claims map[string]interface{}) []string {
-	var present []string
-	for _, claim := range fronteggJWTTemplateReservedClaims {
-		if _, ok := claims[claim]; ok {
-			present = append(present, claim)
-		}
-	}
-	return present
 }
 
 func resourceFronteggJWTTemplateSerialize(d *schema.ResourceData) fronteggJWTTemplate {

--- a/provider/resource_frontegg_jwt_template_test.go
+++ b/provider/resource_frontegg_jwt_template_test.go
@@ -3,10 +3,14 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -243,5 +247,81 @@ func TestResourceFronteggJWTTemplateDeserializeRejectsNonStringClaim(t *testing.
 	}
 	if err := resourceFronteggJWTTemplateDeserialize(d, in); err == nil {
 		t.Fatal("expected an error for a non-string claim value, got nil")
+	}
+}
+
+const testAccJWTTemplateWithTenantID = `
+resource "frontegg_jwt_template" "test" {
+  key         = "tf-acc-tenant-id"
+  name        = "TF acceptance tenantId"
+  description = "FR-26867 regression coverage"
+  expiration  = 3600
+  algorithm   = "RS256"
+
+  claims = {
+    iss      = "{{iss}}"
+    sub      = "{{sub}}"
+    aud      = "{{clientId}}"
+    exp      = "{{exp}}"
+    iat      = "{{iat}}"
+    tenantId = "{{user.tenantId}}"
+    email    = "{{user.email}}"
+  }
+}
+`
+
+func TestAccFronteggJWTTemplate_tenantIDClaimIsAccepted(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckJWTTemplateDestroyed(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTTemplateWithTenantID,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("frontegg_jwt_template.test", "claims.tenantId", "{{user.tenantId}}"),
+					resource.TestCheckResourceAttrSet("frontegg_jwt_template.test", "id"),
+					resource.TestCheckResourceAttrSet("frontegg_jwt_template.test", "vendor_id"),
+				),
+			},
+			{
+				Config:   testAccJWTTemplateWithTenantID,
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      "frontegg_jwt_template.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckJWTTemplateDestroyed(t *testing.T) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		base := os.Getenv("FRONTEGG_API_BASE_URL")
+		if base == "" {
+			base = "https://api.frontegg.com"
+		}
+		token := fronteggVendorToken(t, base)
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "frontegg_jwt_template" {
+				continue
+			}
+			req, err := http.NewRequest(http.MethodGet, base+fronteggJWTTemplatePath+"/"+rs.Primary.ID, nil)
+			if err != nil {
+				return fmt.Errorf("build jwt template lookup: %w", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+token)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return fmt.Errorf("look up jwt template %s: %w", rs.Primary.ID, err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusNotFound {
+				return fmt.Errorf("jwt template %s still exists after destroy (HTTP %d)", rs.Primary.ID, resp.StatusCode)
+			}
+		}
+		return nil
 	}
 }

--- a/provider/resource_frontegg_jwt_template_test.go
+++ b/provider/resource_frontegg_jwt_template_test.go
@@ -1,11 +1,14 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestMissingRequiredClaims(t *testing.T) {
@@ -53,31 +56,76 @@ func TestMissingRequiredClaims(t *testing.T) {
 	}
 }
 
-// TestPresentReservedClaims verifies detection of claims that Frontegg reserves
-// for internal use (type, tenantId), which the API rejects if supplied.
-func TestPresentReservedClaims(t *testing.T) {
-	asClaims := func(keys ...string) map[string]interface{} {
-		m := make(map[string]interface{}, len(keys))
-		for _, k := range keys {
-			m[k] = "{{" + k + "}}"
+func TestResourceFronteggJWTTemplateValidateClaims(t *testing.T) {
+	requiredClaims := map[string]interface{}{
+		"iss": "{{iss}}",
+		"sub": "{{sub}}",
+		"aud": "{{clientId}}",
+		"exp": "{{exp}}",
+		"iat": "{{iat}}",
+	}
+	withClaims := func(extra map[string]string) map[string]interface{} {
+		claims := map[string]interface{}{}
+		for k, v := range requiredClaims {
+			claims[k] = v
 		}
-		return m
+		for k, v := range extra {
+			claims[k] = v
+		}
+		return map[string]interface{}{
+			"key":        "k",
+			"name":       "n",
+			"expiration": 3600,
+			"algorithm":  "RS256",
+			"claims":     claims,
+		}
 	}
 
 	tests := []struct {
-		name   string
-		claims map[string]interface{}
-		want   []string
+		name    string
+		raw     map[string]interface{}
+		wantErr string
 	}{
-		{name: "no reserved claims", claims: asClaims("iss", "sub", "aud", "exp", "iat", "email"), want: nil},
-		{name: "type reserved claim present", claims: asClaims("iss", "type"), want: []string{"type"}},
-		{name: "both reserved in canonical order", claims: asClaims("tenantId", "sub", "type"), want: []string{"type", "tenantId"}},
+		{
+			name: "tenantId is accepted",
+			raw:  withClaims(map[string]string{"tenantId": "{{user.tenantId}}"}),
+		},
+		{
+			name: "type is left to the API",
+			raw:  withClaims(map[string]string{"type": "userToken"}),
+		},
+		{
+			name: "custom claims are accepted",
+			raw:  withClaims(map[string]string{"email": "{{user.email}}"}),
+		},
+		{
+			name: "missing required claims are rejected at plan time",
+			raw: map[string]interface{}{
+				"key":        "k",
+				"name":       "n",
+				"expiration": 3600,
+				"algorithm":  "RS256",
+				"claims":     map[string]interface{}{"email": "{{user.email}}"},
+			},
+			wantErr: "missing: iss, sub, aud, exp, iat",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := presentReservedClaims(tt.claims); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("presentReservedClaims() = %v, want %v", got, tt.want)
+			r := resourceFronteggJWTTemplate()
+			_, err := r.Diff(context.Background(), nil, terraform.NewResourceConfigRaw(tt.raw), nil)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Diff() returned an unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Diff() returned no error, want one")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Diff() error = %q, want it to contain %q", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes [FR-26867](https://frontegg.atlassian.net/browse/FR-26867).

The provider blocked `tenantId` at plan time as "reserved for internal use". It is not reserved server-side, and a user token without it breaks the frontend SDK — so no configuration could produce a working user-token template.

## What was done

- Removed the client-side reserved-claims blocklist; the API's 400 is now authoritative and is surfaced verbatim, naming the offending claim. Removed rather than narrowed because the list was a hand-copied snapshot of server state (and an incomplete one — it blocked 2 of the 9 claims the API actually rejects).
- Kept the required-claims check (`iss/sub/aud/exp/iat`), re-confirmed against the API.
- Fixed the example and `claims` description, which wrongly said `tenantId` is populated by Frontegg; regenerated the docs.
- Added a unit test on the `Resource.Diff` plan path and an acceptance test covering the API round-trip (apply, replan for drift, import, destroy verified by 404).

## Verification

`make lint`, `go test ./...`, and the acceptance test pass against `api.frontegg.com`. Manual `apply` with `tenantId` creates the template and replans clean; `type` still fails with `reservedClaims:["type"]`.


[FR-26867]: https://frontegg.atlassian.net/browse/FR-26867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ